### PR TITLE
Move "isRdma" inside the selectors block

### DIFF
--- a/sriov_roce_cni_install.sh
+++ b/sriov_roce_cni_install.sh
@@ -321,11 +321,11 @@ data:
       "resourceList": [{
           "resourcePrefix": "mellanox.com",
           "resourceName": "sriov_rdma",
-          "isRdma": true,
           "selectors": {
                   "vendors": ["15b3"],
                   "devices": ["1018"],
-                  "drivers": ["mlx5_core"]
+                  "drivers": ["mlx5_core"],
+                  "isRdma": true
               }
       }
       ]


### PR DESCRIPTION
In sriov-network-device-plugin patch [1], they changed how
configs are parsed, now the "isRdma" option should be put
inside the selectors block for it to be effective.

[1]https://github.com/intel/sriov-network-device-plugin/tree/bd43f356c566132d30669bd70ef3f32dab9b194f