### PR TITLE
Rename the ib-sriov-cni plugin name to ib-sriov

### DIFF
--- a/sriov_ib_cni_install.sh
+++ b/sriov_ib_cni_install.sh
@@ -72,7 +72,7 @@ spec:
   config: '{
   "cniVersion": "0.3.1",
   "name": "sriov-network",
-  "plugins":[{"type": "ib-sriov-cni",
+  "plugins":[{"type": "ib-sriov",
   "pkey": "0x223F",
   "link_state": "enable",
   "rdmaIsolation": true,


### PR DESCRIPTION
Following the renaming [1] of ib-sriov-cni bin to ib-sriov, this
patch change the name of the plug-in to ib-sriov instead of
ib-sriov-cni in the crd file.

[1] https://github.com/Mellanox/ib-sriov-cni/commit/d4049a3c5314fd947e394ca3039896f13ffe80d9