### PR TITLE
delete all pods in the clean script

### DIFF
--- a/cni_stop.sh
+++ b/cni_stop.sh
@@ -5,9 +5,19 @@
 export LOGDIR=$WORKSPACE/logs
 export ARTIFACTS=$WORKSPACE/artifacts
 
+export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+
 mkdir -p $WORKSPACE
 mkdir -p $LOGDIR
 mkdir -p $ARTIFACTS
+
+function delete_pods {
+    kubectl delete pods --all
+}
+
+function stop_system_deployments {
+    kubectl delete deployment -n kube-system --all
+}
 
 function stop_system_daemonset {
     for ds in $(kubectl -n kube-system get ds |grep kube|awk '{print $1}'); do
@@ -41,6 +51,10 @@ function delete_chache_files {
     #delete network cache
     rm -rf /var/lib/cni/networks
 }
+
+delete_pods
+
+stop_system_deployments
 
 stop_system_daemonset
 

--- a/sriov_ib_cni_install.sh
+++ b/sriov_ib_cni_install.sh
@@ -179,8 +179,20 @@ function create_vfs {
     echo $VFS_NUM > /sys/class/net/$SRIOV_INTERFACE/device/sriov_numvfs
 }
 
+function reload_modules {
+    systemctl stop opensm
+    /etc/init.d/openibd restart
+    sleep 5
+    systemctl start opensm
+    sleep 2
+    rdma system set netns exclusive
+    sleep 4
+}
+
 
 #TODO add docker image mellanox/mlnx_ofed_linux-4.4-1.0.0.0-centos7.4 presence
+
+reload_modules
 
 if [[ -f ./environment_common.sh ]]; then
     sudo ./environment_common.sh -m "exclusive"


### PR DESCRIPTION
This patch adds the cleaning of all pods in the default namespace
mainly to clean the testing pods of the cis, it also adds the clean
of all the deployments in the kube-system namespace to delete what
remains there, mainly targeting the ib-kubernetes deployment, and
lastly it reload mlnx modules before starting the job for a full clean
up.

fix #30