### PR TITLE
Building ipoib_cni and k8s_rdma_shared_device_plugin from source

### DIFF
--- a/ipoib_cni_install.sh
+++ b/ipoib_cni_install.sh
@@ -14,14 +14,54 @@ export CNI_CONF_DIR=${CNI_CONF_DIR:-/etc/cni/net.d/}
 
 export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
 
+export IPOIB_CNI_REPO=${IPOIB_CNI_REPO:-https://github.com/Mellanox/ipoib-cni.git}
 export IPOIB_CNI_BRANCH=${IPOIB_CNI_BRANCH:-master}
-export K8S_RDMA_SHARED_DEV_PLUGIN=${K8S_RDMA_SHARED_DEV_PLUGIN:-master}
+export IPOIB_CNI_PR=${IPOIB_CNI_PR-''}
+
+export K8S_RDMA_SHARED_DEV_PLUGIN_REPO=${K8S_RDMA_SHARED_DEV_PLUGIN_REPO:-https://github.com/Mellanox/k8s-rdma-shared-dev-plugin.git}
+export K8S_RDMA_SHARED_DEV_PLUGIN_BRANCH=${K8S_RDMA_SHARED_DEV_PLUGIN_BRANCH:-master}
+export K8S_RDMA_SHARED_DEV_PLUGIN_PR=${K8S_RDMA_SHARED_DEV_PLUGIN_PR-''}
 
 echo "Working in $WORKSPACE"
 mkdir -p $WORKSPACE
 mkdir -p $LOGDIR
 mkdir -p $ARTIFACTS
 
+function download_and_build {
+    status=0
+
+    echo "Download $IPOIB_CNI_REPO"
+    rm -rf $WORKSPACE/ipoib-cni
+    git clone $IPOIB_CNI_REPO $WORKSPACE/ipoib-cni
+    pushd $WORKSPACE/ipoib-cni
+    # Check if part of Pull Request and
+    if test ${IPOIB_CNI_PR}; then
+        git fetch --tags --progress $IPOIB_CNI_REPO +refs/pull/$IPOIB_CNI_PR/*:refs/remotes/origin/pr/$IPOIB_CNI_PR/*
+        git pull origin pull/${IPOIB_CNI_PR}/head
+    elif test $IPOIB_CNI_BRANCH; then
+        git checkout $IPOIB_CNI_BRANCH
+    fi
+    
+    make image
+
+    popd
+
+   echo "Download $K8S_RDMA_SHARED_DEV_PLUGIN_REPO"
+    rm -rf $WORKSPACE/k8s-rdma-shared-dev-plugin
+    git clone $K8S_RDMA_SHARED_DEV_PLUGIN_REPO $WORKSPACE/k8s-rdma-shared-dev-plugin
+    pushd $WORKSPACE/k8s-rdma-shared-dev-plugin
+    # Check if part of Pull Request and
+    if test ${K8S_RDMA_SHARED_DEV_PLUGIN_PR}; then
+        git fetch --tags --progress $K8S_RDMA_SHARED_DEV_PLUGIN_REPO +refs/pull/$K8S_RDMA_SHARED_DEV_PLUGIN_PR/*:refs/remotes/origin/pr/$K8S_RDMA_SHARED_DEV_PLUGIN_PR/*
+        git pull origin pull/${K8S_RDMA_SHARED_DEV_PLUGIN_PR}/head
+    elif test $K8S_RDMA_SHARED_DEV_PLUGIN_BRANCH; then
+        git checkout $K8S_RDMA_SHARED_DEV_PLUGIN_BRANCH
+    fi
+
+    make image
+
+    popd
+}
 
 if [[ -f ./environment_common.sh ]]; then
     sudo ./environment_common.sh -m "shared"
@@ -47,12 +87,11 @@ fi
 
 pushd $WORKSPACE
 
-curl https://raw.githubusercontent.com/Mellanox/k8s-rdma-shared-dev-plugin/${K8S_RDMA_SHARED_DEV_PLUGIN}/images/k8s-rdma-shared-dev-plugin-config-map.yaml -o $ARTIFACTS/k8s-rdma-shared-dev-plugin-config-map.yaml
-/usr/local/bin/kubectl create -f $ARTIFACTS/k8s-rdma-shared-dev-plugin-config-map.yaml
-curl https://raw.githubusercontent.com/Mellanox/k8s-rdma-shared-dev-plugin/${K8S_RDMA_SHARED_DEV_PLUGIN}/images/k8s-rdma-shared-dev-plugin-ds.yaml -o $ARTIFACTS/k8s-rdma-shared-dev-plugin-ds.yaml
-/usr/local/bin/kubectl create -f $ARTIFACTS/k8s-rdma-shared-dev-plugin-ds.yaml
-curl https://raw.githubusercontent.com/Mellanox/ipoib-cni/${IPOIB_CNI_BRANCH}/images/ipoib-cni-daemonset.yaml -o $ARTIFACTS/ipoib-cni-daemonset.yaml
-/usr/local/bin/kubectl create -f $ARTIFACTS/ipoib-cni-daemonset.yaml
+download_and_build
+
+/usr/local/bin/kubectl create -f $WORKSPACE/k8s-rdma-shared-dev-plugin/images/k8s-rdma-shared-dev-plugin-config-map.yaml
+/usr/local/bin/kubectl create -f $WORKSPACE/k8s-rdma-shared-dev-plugin/images/k8s-rdma-shared-dev-plugin-ds.yaml
+/usr/local/bin/kubectl create -f $WORKSPACE/ipoib-cni/images/ipoib-cni-daemonset.yaml
 cat  > $ARTIFACTS/pod.yaml <<EOF
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition


### PR DESCRIPTION
This patch build the latest ipoib_cni, and k8s_rdma_shared_device_plugin
image on the host machine, and use them. This is needed to be able
to add a ci for these projects.