### PR TITLE
[WIP]Add ibKubernetesEnabled to the ib_sriov configuration.

### DIFF
--- a/sriov_ib_cni_install.sh
+++ b/sriov_ib_cni_install.sh
@@ -76,6 +76,7 @@ spec:
   "pkey": "0x223F",
   "link_state": "enable",
   "rdmaIsolation": true,
+  "ibKubernetesEnabled" : true, 
   "ipam": {
                 "type": "host-local",
                 "subnet": "10.56.217.0/24",


### PR DESCRIPTION
Adds the ibKubernetesEnabled: true to the ib_sriov cni configuration
to use the guid from ib_kubernetes. This ensure that the pod will
always have a guid and if not, it will fail.