### PR TITLE
Add a number of retries to the "reset guids" test

### DIFF
--- a/sriov_ib_cni_install.sh
+++ b/sriov_ib_cni_install.sh
@@ -175,7 +175,7 @@ EOF
 
 function create_vfs {
     if [ $SRIOV_INTERFACE == 'auto_detect' ]; then
-        export SRIOV_INTERFACE=$(ls -l /sys/class/net/ | grep $(lspci |grep Mellanox | grep MT27800|head -n1|awk '{print $1}') | awk '{print $9}')
+        export SRIOV_INTERFACE=$(ls -l /sys/class/net/ | grep $(lspci |grep Mellanox | grep -Ev 'MT27500|MT27520'|head -n1|awk '{print $1}') | awk '{print $9}')
     fi
     echo $VFS_NUM > /sys/class/net/$SRIOV_INTERFACE/device/sriov_numvfs
 }


### PR DESCRIPTION
In an effort to reproduce the bug with the ib-sriov-cni where it
fails to reset VFs GUIDs after deletion. A number of retries to the
"reset guids" test in ib_sriov_cni_test.sh was added so that it
will increase the chance of the bug appearing.