### PR TITLE
Switch to kubeadm

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The projects use environment variables to configure their components. Each proje
 |EXTERNAL_HOSTNAME | hostname | this is used to configure Kubernetes local_cluser_up.sh EXTERNAL_HOSTNAME |
 |API_HOST_IP | host ip | this is used to configure Kubernetes local_cluser_up.sh API_HOST_IP |
 |KUBELET_HOST | host ip | this is used to configure Kubernetes local_cluser_up.sh KUBELET_HOST |
-|KUBECONFIG | /var/run/kubernetes/admin.kubeconfig | this is used to configure Kubernetes local_cluser_up.sh KUBECONFIG |
+|KUBECONFIG | /etc/kubernetes/admin.conf | this is used to configure Kubernetes local_cluser_up.sh KUBECONFIG |
 |NETWORK | "192.168.$N" | this is used to setup the macvlan network range, N is randomly generated |
 
 For more information on each project, please see the related project README.

--- a/clean_common.sh
+++ b/clean_common.sh
@@ -19,10 +19,9 @@ function stop_system_daemonset {
     done
 }
 
-function stop_k8s_screen {
-    for sc in $(screen -ls|grep multus|awk '{print $1}'); do
-        screen -X -S $sc quit
-    done
+function stop_k8s {
+    kubeadm reset -f
+    rm -rf $HOME/.kube/config
 }
 
 function asure_all_stoped {
@@ -107,7 +106,23 @@ function unload_module {
     fi
 }
 
-let status=0
+function general_cleaning {
+    stop_system_deployments
+
+    stop_system_daemonset
+
+    stop_k8s
+
+    asure_all_stoped
+
+    delete_chache_files
+
+    delete_all_docker_container
+
+    delete_all_docker_images
+
+    clean_tmp_workspaces
+}
 
 function load_core_drivers {
     modprobe mlx5_core

--- a/cni_stop.sh
+++ b/cni_stop.sh
@@ -5,7 +5,7 @@
 export LOGDIR=$WORKSPACE/logs
 export ARTIFACTS=$WORKSPACE/artifacts
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 mkdir -p $WORKSPACE
 mkdir -p $LOGDIR
@@ -17,22 +17,8 @@ function main {
 
     delete_pods
 
-    stop_system_deployments
+    general_cleaning
 
-    stop_system_daemonset
-    
-    stop_k8s_screen
-    
-    asure_all_stoped
-    
-    delete_chache_files
-    
-    delete_all_docker_container
-    
-    delete_all_docker_images
-    
-    clean_tmp_workspaces
-    
     reset_vfs_guids
     
     cp /tmp/kube*.log $LOGDIR

--- a/deploy/kubelet/kubelet.service
+++ b/deploy/kubelet/kubelet.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/
+
+[Service]
+ExecStart=/usr/local/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/kubelet/kubelet.service.d/10-kubeadm.conf
+++ b/deploy/kubelet/kubelet.service.d/10-kubeadm.conf
@@ -1,0 +1,11 @@
+# Note: This dropin only works with kubeadm and kubelet v1.11+
+[Service]
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+# This is a file that "kubeadm init" and "kubeadm join" generates at runtime, populating the KUBELET_KUBEADM_ARGS variable dynamically
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+# This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+# the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+EnvironmentFile=-/etc/sysconfig/kubelet
+ExecStart=
+ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS

--- a/ipoib_cni_install.sh
+++ b/ipoib_cni_install.sh
@@ -13,7 +13,7 @@ export PATH=/usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$P
 export CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin/}
 export CNI_CONF_DIR=${CNI_CONF_DIR:-/etc/cni/net.d/}
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 export IPOIB_CNI_REPO=${IPOIB_CNI_REPO:-https://github.com/Mellanox/ipoib-cni.git}
 export IPOIB_CNI_BRANCH=${IPOIB_CNI_BRANCH:-master}

--- a/ipoib_cni_test.sh
+++ b/ipoib_cni_test.sh
@@ -12,7 +12,7 @@ export TIMEOUT=${TIMEOUT:-300}
 export POLL_INTERVAL=${POLL_INTERVAL:-10}
 export NETWORK=${NETWORK:-'192.168'}
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 export K8S_RDMA_SHARED_DEV_PLUGIN=${K8S_RDMA_SHARED_DEV_PLUGIN:-master}
 
 pushd $WORKSPACE

--- a/nic_operator/nic_operator_ci_start.sh
+++ b/nic_operator/nic_operator_ci_start.sh
@@ -16,7 +16,7 @@ export PATH=/usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$P
 
 export CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin/}
 export CNI_CONF_DIR=${CNI_CONF_DIR:-/etc/cni/net.d/}
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 export KERNEL_VERSION=${KERNEL_VERSION:-4.15.0-109-generic}
 export OS_DISTRO=${OS_DISTRO:-ubuntu}

--- a/nic_operator/nic_operator_ci_stop.sh
+++ b/nic_operator/nic_operator_ci_stop.sh
@@ -4,7 +4,7 @@ set -x
 export LOGDIR=$WORKSPACE/logs
 export ARTIFACTS=$WORKSPACE/artifacts
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 source ./clean_common.sh
 
@@ -23,26 +23,10 @@ function main {
     delete_pods
     
     delete_nic_operator_namespace
-    
-    stop_system_deployments
-    
-    stop_system_daemonset
-    
-    stop_k8s_screen
-    
-    asure_all_stoped
-    
-    delete_chache_files
-    
-    delete_all_docker_container
-    
-    delete_all_docker_images
-    
-    clean_tmp_workspaces
-    
+
+    general_cleaning
+ 
     load_core_drivers                                                                                                                                                                                                                            
-    let status=$status+$?
-    
     cp /tmp/kube*.log $LOGDIR
     echo "All logs $LOGDIR"
     echo "All confs $ARTIFACTS"

--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -11,7 +11,7 @@ export TIMEOUT=${TIMEOUT:-300}
 
 export POLL_INTERVAL=${POLL_INTERVAL:-10}
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 export SRIOV_INTERFACE=${SRIOV_INTERFACE:-auto_detect}
 

--- a/sriov_antrea_cni_install.sh
+++ b/sriov_antrea_cni_install.sh
@@ -20,7 +20,7 @@ export PATH=/usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$P
 
 export CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin/}
 export CNI_CONF_DIR=${CNI_CONF_DIR:-/etc/cni/net.d/}
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 #TODO add autodiscovering
 export SRIOV_INTERFACE=${SRIOV_INTERFACE:-auto_detect}

--- a/sriov_antrea_cni_test.sh
+++ b/sriov_antrea_cni_test.sh
@@ -12,7 +12,7 @@ export TIMEOUT=${TIMEOUT:-300}
 export POLL_INTERVAL=${POLL_INTERVAL:-10}
 export NETWORK=${NETWORK:-'192.168'}
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 export K8S_RDMA_SHARED_DEV_PLUGIN=${K8S_RDMA_SHARED_DEV_PLUGIN:-master}
 
 mkdir -p $WORKSPACE

--- a/sriov_cni_install.sh
+++ b/sriov_cni_install.sh
@@ -25,7 +25,7 @@ export PATH=/usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$P
 export CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin/}
 export CNI_CONF_DIR=${CNI_CONF_DIR:-/etc/cni/net.d/}
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 # generate random network
 N=$((1 + RANDOM % 128))

--- a/sriov_cni_test.sh
+++ b/sriov_cni_test.sh
@@ -12,7 +12,7 @@ export TIMEOUT=${TIMEOUT:-300}
 export POLL_INTERVAL=${POLL_INTERVAL:-10}
 export NETWORK=${NETWORK:-'192.168'}
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 export K8S_RDMA_SHARED_DEV_PLUGIN=${K8S_RDMA_SHARED_DEV_PLUGIN:-master}
 
 mkdir -p $WORKSPACE

--- a/sriov_ib_cni_install.sh
+++ b/sriov_ib_cni_install.sh
@@ -25,7 +25,7 @@ export PATH=/usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$P
 export CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin/}
 export CNI_CONF_DIR=${CNI_CONF_DIR:-/etc/cni/net.d/}
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 # generate random network
 N=$((1 + RANDOM % 128))

--- a/sriov_ib_cni_test.sh
+++ b/sriov_ib_cni_test.sh
@@ -12,7 +12,7 @@ export TIMEOUT=${TIMEOUT:-300}
 export POLL_INTERVAL=${POLL_INTERVAL:-10}
 export NETWORK=${NETWORK:-'192.168'}
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 export K8S_RDMA_SHARED_DEV_PLUGIN=${K8S_RDMA_SHARED_DEV_PLUGIN:-master}
 
 export SRIOV_INTERFACE=${SRIOV_INTERFACE:-auto_detect}


### PR DESCRIPTION
Before this point, the CIs were using the local-up-cluster.sh script
to start the Kubernetes cluster (local-up-cluster.sh is a script provided
by the kubernetes project, that run the kubelet and kube-api together. It
is mainly used for testing). This is bad since in production, kubeadm is
usually used, also kubeadm is easier to run and maintain, and provide the
ability to do multi-node CIs in the future.