### PR TITLE
test the new selectoros for the k8s-rdma-shared-dev-plugin

### DIFF
--- a/ipoib/ipoib_ci_start.sh
+++ b/ipoib/ipoib_ci_start.sh
@@ -66,6 +66,8 @@ create_workspace
 
 get_arch
 
+cp ./ipoib/yaml/k8s-rdma-shared-device-plugin-configmap.yaml ${ARTIFACTS}/
+
 pushd $WORKSPACE
 
 load_rdma_modules
@@ -88,7 +90,7 @@ fi
 
 download_and_build
 
-/usr/local/bin/kubectl create -f $WORKSPACE/k8s-rdma-shared-dev-plugin/images/k8s-rdma-shared-dev-plugin-config-map.yaml
+/usr/local/bin/kubectl create -f ${ARTIFACTS}/k8s-rdma-shared-device-plugin-configmap.yaml
 /usr/local/bin/kubectl create -f $WORKSPACE/k8s-rdma-shared-dev-plugin/images/k8s-rdma-shared-dev-plugin-ds.yaml
 /usr/local/bin/kubectl create -f $WORKSPACE/ipoib-cni/images/ipoib-cni-daemonset.yaml
 cat  > $ARTIFACTS/pod.yaml <<EOF

--- a/ipoib/yaml/k8s-rdma-shared-device-plugin-configmap.yaml
+++ b/ipoib/yaml/k8s-rdma-shared-device-plugin-configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rdma-devices
+  namespace: kube-system
+data:
+  config.json: |
+    {
+        "configList": [{
+             "resourceName": "hca_shared_devices_a",
+             "rdmaHcaMax": 1000,
+             "devices": ["ib0"]
+           },
+           {
+             "resourceName": "hca_shared_devices_b",
+             "rdmaHcaMax": 500,
+             "selectors": {
+               "vendors": ["15b3"],
+               "deviceIDs": ["1017"],
+               "ifNames": ["ib0"]
+             }
+           }
+        ]
+    }


### PR DESCRIPTION
With [1], the k8s-rdma-shared-dev-plugin supports a new way of
selecting RDMA devices to use. This patch tests the selectors
in addition to the old devices interface names.

[1] https://github.com/Mellanox/k8s-rdma-shared-dev-plugin/pull/19