### PR TITLE
Collect logs of pods and services

### DIFF
--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -48,6 +48,8 @@ create_workspace(){
     mkdir -p $WORKSPACE
     mkdir -p $LOGDIR
     mkdir -p $ARTIFACTS
+
+    date +"%Y-%m-%d %H:%M:%S" > ${LOGDIR}/start-time.log
 }
 
 get_arch(){

--- a/ipoib/ipoib_ci_stop.sh
+++ b/ipoib/ipoib_ci_stop.sh
@@ -14,6 +14,8 @@ function main {
 
     delete_pods
 
+    collect_pods_logs
+
     general_cleaning
     
     cp /tmp/kube*.log $LOGDIR

--- a/nic_operator/nic_operator_ci_start.sh
+++ b/nic_operator/nic_operator_ci_start.sh
@@ -136,10 +136,7 @@ function patch_pod_cider_to_node {
 }
 
 function main {
-    echo "Working in $WORKSPACE"
-    mkdir -p $WORKSPACE
-    mkdir -p $LOGDIR
-    mkdir -p $ARTIFACTS
+    create_workspace
 
     echo "Get CPU architechture"
     export ARCH="amd"

--- a/nic_operator/nic_operator_ci_stop.sh
+++ b/nic_operator/nic_operator_ci_stop.sh
@@ -21,6 +21,8 @@ function main {
 
     delete_pods
     
+    collect_pods_logs
+
     delete_nic_operator_namespace
 
     general_cleaning

--- a/sriov/sriov_ci_stop.sh
+++ b/sriov/sriov_ci_stop.sh
@@ -3,7 +3,7 @@
 export LOGDIR=$WORKSPACE/logs
 export ARTIFACTS=$WORKSPACE/artifacts
 
-export KUBECONFIG=${KUBECONFIG:-/var/run/kubernetes/admin.kubeconfig}
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 source ./common/clean_common.sh
 
@@ -13,6 +13,8 @@ function main {
     mkdir -p $ARTIFACTS
 
     delete_pods
+
+    collect_pods_logs
 
     general_cleaning
  

--- a/sriov_antrea/sriov_antrea_ci_stop.sh
+++ b/sriov_antrea/sriov_antrea_ci_stop.sh
@@ -14,6 +14,8 @@ function main {
 
     delete_pods
 
+    collect_pods_logs
+
     general_cleaning
     
     cp /tmp/kube*.log $LOGDIR

--- a/sriov_ib/sriov_ib_ci_stop.sh
+++ b/sriov_ib/sriov_ib_ci_stop.sh
@@ -14,6 +14,8 @@ function main {
 
     delete_pods
 
+    collect_pods_logs
+
     general_cleaning
 
     reset_vfs_guids


### PR DESCRIPTION
Before this point logs were collected in a Jenkins build step that
would look for logs inside the /tmp dir. This is where the local_cluster_up.sh
used to save the logs. Since moving to kubeadm, the logs are now split
between the kube-api pod, and the kubelet service. This patch collects
the logs from all the pods deployed in the system, and from the kubelet
and docker service and adds them to the LOGDIR directory.

fixes #57 