### PR TITLE
Change the NicClusterPolicy name to nic-cluster-policy

### DIFF
--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -25,7 +25,7 @@ function nic_policy_create {
     fi
 
     nic_operator_dir=$WORKSPACE/mellanox-network-operator/deploy
-    cr_file=$ARTIFACTS/ofed-rdma-nic-policy.yaml
+    cr_file=$ARTIFACTS/nic-cluster-policy.yaml
 
     replace_placeholder REPLACE_INTERFACE $SRIOV_INTERFACE $cr_file
     kubectl create -f "$cr_file"

--- a/nic_operator/yaml/nic-cluster-policy.yaml
+++ b/nic_operator/yaml/nic-cluster-policy.yaml
@@ -14,7 +14,7 @@
 apiVersion: mellanox.com/v1alpha1
 kind: NicClusterPolicy
 metadata:
-  name: ofed-rdma-nicclusterpolicy
+  name: nic-cluster-policy
   namespace: mlnx-network-operator
 spec:
   ofedDriver:


### PR DESCRIPTION
Following [1], the Network Operator only listens to a NicClusterPolicy
with the name nic-cluster-policy. This patch changes the deployed NicClusterPolicy
name to the predefined name.

[1] https://github.com/Mellanox/network-operator/pull/38