### PR TITLE
Add mlx_compat and mlx5_ib to the tested modules

### DIFF
--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -95,6 +95,10 @@ Testing ofed drivers ..."
     let status=status+$?
     verfiy_module ib_core
     let status=status+$?
+    verfiy_module mlx_compat
+    let status=status+$?
+    verfiy_module mlx5_ib
+    let status=status+$?
 
     if [[ "$status" == "0" ]]; then
         echo "Success!! all ofed modules are verified."


### PR DESCRIPTION
when RDMA core is installed on the host we saw that module loading
is triggered by udev after mlx5_core is loaded. this causes host
modules to be loaded for some modules. This patch adds more OFED
core modules to be tested when the OFED driver container is deployed.