### PR TITLE
Switch to k8snetworkplumbingwg repo in the SRIOV jobs

### DIFF
--- a/sriov/README.md
+++ b/sriov/README.md
@@ -8,8 +8,8 @@ The SRIOV project builds and deploy the following components:
 * [Multus](https://github.com/intel/multus-cni).
 * [Container networking plugins](https://github.com/containernetworking/plugins.git).
 * [Mellanox RDMA cni](https://github.com/Mellanox/rdma-cni).
-* [SRIOV network device plugin](https://github.com/intel/sriov-network-device-plugin).
-* [SRIOV cni](https://github.com/intel/sriov-cni). 
+* [SRIOV network device plugin](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin).
+* [SRIOV cni](https://github.com/k8snetworkplumbingwg/sriov-cni). 
 
 ### Configurations
 In addition to the common configurations found at [README.md](./README.md), the sriov project uses the following configurations:
@@ -19,10 +19,10 @@ In addition to the common configurations found at [README.md](./README.md), the 
 |  RDMA_CNI_REPO | https://github.com/Mellanox/rdma-cni | RDMA cni repo to use |
 |  RDMA_CNI_BRANCH | master | RDMA cni branch to use |
 |  RDMA_CNI_PR | | RDMA cni pull request to pull, adding this will ignore RDMA_CNI_BRANCH |
-|  SRIOV_CNI_REPO | https://github.com/intel/sriov-cni | SRIOV cni repo to use |
+|  SRIOV_CNI_REPO | https://github.com/k8snetworkplumbingwg/sriov-cni | SRIOV cni repo to use |
 |  SRIOV_CNI_BRANCH | master | SRIOV cni branch to use |
 |  SRIOV_CNI_PR | '' | SRIOV cni pull request to pull,  adding this will ignore SRIOV_CNI_BRANCH |
-|  SRIOV_NETWORK_DEVICE_PLUGIN_REPO | https://github.com/intel/sriov-network-device-plugin | SRIOV network device plugin repo to use |
+|  SRIOV_NETWORK_DEVICE_PLUGIN_REPO | https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin | SRIOV network device plugin repo to use |
 |  SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH | master | SRIOV network device plugin branch to build |
 |  SRIOV_NETWORK_DEVICE_PLUGIN_PR-'' | SRIOV network device plugin pull request to pull, adding this will ignore SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH |
 |  MACVLAN_INTERFACE | eno1 | macvlan network master interface |

--- a/sriov/sriov_ci_start.sh
+++ b/sriov/sriov_ci_start.sh
@@ -11,11 +11,11 @@ export RDMA_CNI_REPO=${RDMA_CNI_REPO:-https://github.com/Mellanox/rdma-cni}
 export RDMA_CNI_BRANCH=${RDMA_CNI_BRANCH:-master}
 export RDMA_CNI_PR=${RDMA_CNI_PR:-''}
 
-export SRIOV_CNI_REPO=${SRIOV_CNI_REPO:-https://github.com/intel/sriov-cni}
+export SRIOV_CNI_REPO=${SRIOV_CNI_REPO:-https://github.com/k8snetworkplumbingwg/sriov-cni}
 export SRIOV_CNI_BRANCH=${SRIOV_CNI_BRANCH:-master}
 export SRIOV_CNI_PR=${SRIOV_CNI_PR:-''}
 
-export SRIOV_NETWORK_DEVICE_PLUGIN_REPO=${SRIOV_NETWORK_DEVICE_PLUGIN_REPO:-https://github.com/intel/sriov-network-device-plugin}
+export SRIOV_NETWORK_DEVICE_PLUGIN_REPO=${SRIOV_NETWORK_DEVICE_PLUGIN_REPO:-https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin}
 export SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH=${SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH:-master}
 export SRIOV_NETWORK_DEVICE_PLUGIN_PR=${SRIOV_NETWORK_DEVICE_PLUGIN_PR-''}
 

--- a/sriov_antrea/README.md
+++ b/sriov_antrea/README.md
@@ -7,7 +7,7 @@ The SRIOV ANTREA project builds and deploy the following components:
 * [Kubernetes](https://github.com/kubernetes/kubernetes).
 * [Multus](https://github.com/intel/multus-cni).
 * [Container networking plugins](https://github.com/containernetworking/plugins.git).
-* [SRIOV network device plugin](https://github.com/intel/sriov-network-device-plugin).
+* [SRIOV network device plugin](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin).
 * [vmware antrea project](https://github.com/vmware-tanzu/antrea.git). 
 
 ### Configurations
@@ -18,7 +18,7 @@ In addition to the common configurations found at [README.md](./README.md), the 
 |  ANTREA_CNI_REPO | https://github.com/vmware-tanzu/antrea.git | antrea project repo to use |
 |  ANTREA_CNI_BRANCH | master | antrea project branch to use |
 |  ANTREA_CNI_PR | | antrea project pull request to pull, adding this will ignore ANTREA_CNI_BRANCH |
-|  SRIOV_NETWORK_DEVICE_PLUGIN_REPO | https://github.com/intel/sriov-network-device-plugin | SRIOV network device plugin repo to use |
+|  SRIOV_NETWORK_DEVICE_PLUGIN_REPO | https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin | SRIOV network device plugin repo to use |
 |  SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH | master | SRIOV network device plugin branch to build |
 |  SRIOV_NETWORK_DEVICE_PLUGIN_PR-'' | SRIOV network device plugin pull request to pull, adding this will ignore SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH |
 |  SRIOV_INTERFACE | auto_detect | SRIOV network device, if not specified, the first Mellanox card will be used (does not support ConnectX3) |

--- a/sriov_antrea/sriov_antrea_ci_start.sh
+++ b/sriov_antrea/sriov_antrea_ci_start.sh
@@ -11,7 +11,7 @@ export ANTREA_CNI_REPO=${ANTREA_CNI_REPO:-https://github.com/vmware-tanzu/antrea
 export ANTREA_CNI_BRANCH=${ANTREA_CNI_BRANCH:-master}
 export ANTREA_CNI_PR=${ANTREA_CNI_PR:-''}
 
-export SRIOV_NETWORK_DEVICE_PLUGIN_REPO=${SRIOV_NETWORK_DEVICE_PLUGIN_REPO:-https://github.com/intel/sriov-network-device-plugin}
+export SRIOV_NETWORK_DEVICE_PLUGIN_REPO=${SRIOV_NETWORK_DEVICE_PLUGIN_REPO:-https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin}
 export SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH=${SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH:-master}
 export SRIOV_NETWORK_DEVICE_PLUGIN_PR=${SRIOV_NETWORK_DEVICE_PLUGIN_PR-''}
 

--- a/sriov_ib/README.md
+++ b/sriov_ib/README.md
@@ -8,7 +8,7 @@ The SRIOV IB project builds and deploy the following components:
 * [Multus](https://github.com/intel/multus-cni).
 * [Container networking plugins](https://github.com/containernetworking/plugins.git).
 * [Mellanox IB Kubernetes](https://github.com/Mellanox/ib-kubernetes).
-* [SRIOV network device plugin](https://github.com/intel/sriov-network-device-plugin).
+* [SRIOV network device plugin](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin).
 * [Mellanox IB SRIOV CNI](https://github.com/mellanox/ib-sriov-cni). 
 
 ### Configurations
@@ -22,7 +22,7 @@ In addition to the common configurations found at [README.md](./README.md), the 
 | SRIOV_IB_CNI_REPO | https://github.com/mellanox/ib-sriov-cni | IB SRIOV CNI repo to use |
 | SRIOV_IB_CNI_BRANCH | master | IB SRIOV project branch to build |
 | SRIOV_IB_CNI_PR | '' | IB SRIOV pull request to pull, adding this will ignore SRIOV_IB_CNI_BRANCH |
-| SRIOV_NETWORK_DEVICE_PLUGIN_REPO | https://github.com/intel/sriov-network-device-plugin | SRIOV network device plugin repo to use |
+| SRIOV_NETWORK_DEVICE_PLUGIN_REPO | https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin | SRIOV network device plugin repo to use |
 | SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH | master | SRIOV network device plugin branch to build |
 | SRIOV_NETWORK_DEVICE_PLUGIN_PR-'' | SRIOV network device plugin pull request to pull, adding this will ignore SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH |
 | MACVLAN_INTERFACE | eno1 | macvlan network master interface |

--- a/sriov_ib/sriov_ib_ci_start.sh
+++ b/sriov_ib/sriov_ib_ci_start.sh
@@ -15,7 +15,7 @@ export SRIOV_IB_CNI_REPO=${SRIOV_IB_CNI_REPO:-https://github.com/mellanox/ib-sri
 export SRIOV_IB_CNI_BRANCH=${SRIOV_IB_CNI_BRANCH:-master}
 export SRIOV_IB_CNI_PR=${SRIOV_IB_CNI_PR:-''}
 
-export SRIOV_NETWORK_DEVICE_PLUGIN_REPO=${SRIOV_NETWORK_DEVICE_PLUGIN_REPO:-https://github.com/intel/sriov-network-device-plugin}
+export SRIOV_NETWORK_DEVICE_PLUGIN_REPO=${SRIOV_NETWORK_DEVICE_PLUGIN_REPO:-https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin}
 export SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH=${SRIOV_NETWORK_DEVICE_PLUGIN_BRANCH:-master}
 export SRIOV_NETWORK_DEVICE_PLUGIN_PR=${SRIOV_NETWORK_DEVICE_PLUGIN_PR-''}
 


### PR DESCRIPTION
Changed the sriov-network-device-plugin and the sriov-cni repos from
Intel to k8snetworkplumbingwg in the related jobs (sriov, sriov_ib, and
sriov_antrea).