### PR TITLE
Deploy all CRDS in crds dir in nic_operator project

### DIFF
--- a/nic_operator/nic_operator_ci_start.sh
+++ b/nic_operator/nic_operator_ci_start.sh
@@ -101,8 +101,11 @@ function deploy_operator_components {
     kubectl create -f role_binding.yaml
     let status=status+$?
 
-    kubectl create -f crds/mellanox.com_nicclusterpolicies_crd.yaml
-    let status=status+$?
+    for file in $(find ./crds/ -type f -name *_crd.yaml);do
+        kubectl apply -f "$file"
+        let status=status+$?
+        sleep 2
+    done
 
     kubectl create -f operator.yaml
     let status=status+$?


### PR DESCRIPTION
This patch makes the nic_operator project deploy all the files
ending with _crd.yaml in the deploy/crds dir of the network-operator
project. This is necessary to have all the custom definitions ready
for the network operator pods to work probably.