### PR TITLE
Add the secondary network test

### DIFF
--- a/nic_operator/yaml/sample-macvlan-cr.yaml
+++ b/nic_operator/yaml/sample-macvlan-cr.yaml
@@ -1,0 +1,42 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Note(abdallahyas): This file is just to show how the yaml will look like
+# at the end, this will be overwritten by the test scripts.
+apiVersion: mellanox.com/v1alpha1
+kind: MacvlanNetwork
+metadata:
+  name: example-macvlannetwork
+spec:
+  networkNamespace: "default"
+  master: "REPLACE_INTERFACE"
+  mode: "bridge"
+  mtu: 1500
+  ipam: |
+    {
+      "type": "whereabouts",
+      "datastore": "kubernetes",
+      "kubernetes": {
+        "kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"
+      },
+      "range": "192.168.2.225/28",
+      "exclude": [
+       "192.168.2.229/30",
+       "192.168.2.236/32"
+      ],
+      "log_file" : "/var/log/whereabouts.log",
+      "log_level" : "info",
+      "gateway": "192.168.2.1"
+    }
+

--- a/nic_operator/yaml/secondary-network-nic-cluster-policy.yaml
+++ b/nic_operator/yaml/secondary-network-nic-cluster-policy.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 NVIDIA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Note(abdallahyas): This file is just to show how the yaml will look like
+# at the end, this will be overwritten by the test scripts.
+apiVersion: mellanox.com/v1alpha1
+kind: NicClusterPolicy
+metadata:
+  name: nic-cluster-policy
+  namespace: mlnx-network-operator
+spec:
+  secondaryNetwork:
+    cniPlugins:
+      image: containernetworking-plugins
+      repository: mellanox
+      version: v0.8.7
+    multus:
+      image: multus
+      repository: nfvpe
+      version: v3.6
+      config: ''
+    ipamPlugin:
+      image: whereabouts
+      repository: dougbtv
+      version: latest
+


### PR DESCRIPTION
Added the test to test the Network Operator secondary network
feature, the test deploys multus, macvlan, and ipam plugins,
and create a macvlan network, after that ICMP traffic is tested
between workload pods created on the macvlan network.