### PR TITLE
Reload Mellanox drivers after deleting the nic-cluster-policy

### DIFF
--- a/common/clean_common.sh
+++ b/common/clean_common.sh
@@ -129,8 +129,8 @@ function general_cleaning {
 }
 
 function load_core_drivers {
-    modprobe mlx5_core
-    modprobe ib_core
+    sudo modprobe mlx5_core
+    sudo modprobe ib_core
 }
 
 function collect_pods_logs {
@@ -227,6 +227,9 @@ function delete_nic_cluster_policies {
     kubectl delete $nic_cluster_policy_name --all --wait=true
 
     asure_resource_deleted "pods" "$resources_namespace"
+
+	    load_core_drivers
+    sleep 5
 }
 
 function asure_resource_deleted {


### PR DESCRIPTION
Added a reload of the Mellanox modules after deleting the nic-cluster-policy
. This is to remove the need for it when the OFED driver is unloaded.