### PR TITLE
Change the OFED driver container repo to harbor repo

### DIFF
--- a/nic_operator/nic_operator_ci_start.sh
+++ b/nic_operator/nic_operator_ci_start.sh
@@ -18,7 +18,7 @@ export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 export KERNEL_VERSION=${KERNEL_VERSION:-4.15.0-109-generic}
 export OS_DISTRO=${OS_DISTRO:-ubuntu}
-export OS_VERSION=${OS_VERSION:-18.04}
+export OS_VERSION=${OS_VERSION:-20.04}
 
 source ./common/common_functions.sh
 

--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -16,7 +16,7 @@ export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 export SRIOV_INTERFACE=${SRIOV_INTERFACE:-auto_detect}
 
 export OFED_DRIVER_IMAGE=${OFED_DRIVER_IMAGE:-'ofed-driver'}
-export OFED_DRIVER_REPO=${OFED_DRIVER_REPO:-'mellanox'}
+export OFED_DRIVER_REPO=${OFED_DRIVER_REPO:-'harbor.mellanox.com/cloud-orchestration'}
 export OFED_DRIVER_VERSION=${OFED_DRIVER_VERSION:-'5.0-2.1.8.0'}
 
 export DEVICE_PLUGIN_IMAGE=${DEVICE_PLUGIN_IMAGE:-'k8s-rdma-shared-dev-plugin'}


### PR DESCRIPTION
Changed the OFED driver container image repo to be mellanox internal
repo, this is because the ubuntu20 image is not yet GA and can not
be uploaded to docker hub, and using the ubuntu20 image will increase
the CI speed, since it will not rebuild the kernel modules.