### PR TITLE
Delete antrea CNI runtime files

### DIFF
--- a/sriov_antrea/sriov_antrea_ci_stop.sh
+++ b/sriov_antrea/sriov_antrea_ci_stop.sh
@@ -7,6 +7,10 @@ export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 source ./common/clean_common.sh
 
+function clean_antrea_runtime {
+    rm -rf /var/run/antrea/
+}
+
 function main {
     mkdir -p $WORKSPACE
     mkdir -p $LOGDIR
@@ -17,6 +21,8 @@ function main {
     collect_pods_logs
 
     general_cleaning
+
+    clean_antrea_runtime
     
     cp /tmp/kube*.log $LOGDIR
     echo "All logs $LOGDIR"


### PR DESCRIPTION
Added a cleanup of the antrea CNI runtime configurations found at
[1], This was motivated because the IP pool was fully populated
and was not being cleaned automatically (sometimes), so the CNI
was failing to assign an IP to newly created pods.

[1] /var/run/antrea