### PR TITLE
Disable deleting docker images every job

### DIFF
--- a/common/clean_common.sh
+++ b/common/clean_common.sh
@@ -121,7 +121,7 @@ function general_cleaning {
 
     delete_all_docker_container
 
-    delete_all_docker_images
+#    delete_all_docker_images
 
     clean_tmp_workspaces
 


### PR DESCRIPTION
Because of DockerHub new pull rate limit on anonymous users, the
CIs started to fail because it was hitting the limit when trying
to pull the images for the Kubernetes pods. This patch disables
the docker images cleaning, so that the CIs will minimize the number
of pulls it will perform when triggered.