### PR TITLE
Build the antrea project from the fetched SCM

### DIFF
--- a/sriov_antrea/sriov_antrea_ci_test.sh
+++ b/sriov_antrea/sriov_antrea_ci_test.sh
@@ -143,7 +143,7 @@ function exit_code {
     rc="$1"
     echo "All logs $LOGDIR"
     echo "All confs $ARTIFACTS"
-    echo "To stop K8S run # WORKSPACE=${WORKSPACE} ./cni_stop.sh"
+    echo "To stop K8S run # WORKSPACE=${WORKSPACE} ./sriov_antrea/sriov_antrea_ci_stop.sh"
     exit $status
 }
 


### PR DESCRIPTION
Following vmware request to use the jenkins github SCM to fetch the
pull requests instead of doing manually, two changes were made:
* The jenkins would copy the fetched SCM to the CI machine.
* The sriov_antrea project would use the copied SCM.

This patch do the change to the sriov_antrea project.