### PR TITLE
Change the ofed image to cloud-orchestration/mofed-5.0-2.1.8.0

### DIFF
--- a/nic_operator/nic_operator_ci_start.sh
+++ b/nic_operator/nic_operator_ci_start.sh
@@ -18,7 +18,7 @@ export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 export KERNEL_VERSION=${KERNEL_VERSION:-4.15.0-109-generic}
 export OS_DISTRO=${OS_DISTRO:-ubuntu}
-export OS_VERSION=${OS_VERSION:-18.04}
+export OS_VERSION=${OS_VERSION:-20.04}
 
 source ./common/common_functions.sh
 

--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -16,8 +16,8 @@ export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 export SRIOV_INTERFACE=${SRIOV_INTERFACE:-auto_detect}
 
 export OFED_DRIVER_IMAGE=${OFED_DRIVER_IMAGE:-'mofed'}
-export OFED_DRIVER_REPO=${OFED_DRIVER_REPO:-'harbor.mellanox.com/sw-linux-devops'}
-export OFED_DRIVER_VERSION=${OFED_DRIVER_VERSION:-'5.2-0.3.1.0'}
+export OFED_DRIVER_REPO=${OFED_DRIVER_REPO:-'harbor.mellanox.com/cloud-orchestration'}
+export OFED_DRIVER_VERSION=${OFED_DRIVER_VERSION:-'5.0-2.1.8.0'}
 
 export DEVICE_PLUGIN_IMAGE=${DEVICE_PLUGIN_IMAGE:-'k8s-rdma-shared-dev-plugin'}
 export DEVICE_PLUGIN_REPO=${DEVICE_PLUGIN_REPO:-'mellanox'}


### PR DESCRIPTION
The OFED container image mofed-5.2-0.4.2.0 is broken because of a
new module dependency. Switching back to the old image that was used
, but renamed it to match the new format.