### PR TITLE
Change to mofed to version 5.2-0.5.7.0 and uninstall rdma-core

### DIFF
--- a/common/nic_operator_common.sh
+++ b/common/nic_operator_common.sh
@@ -21,8 +21,8 @@ export NIC_OPERATOR_PR=${NIC_OPERATOR_PR:-''}
 export NIC_OPERATOR_HARBOR_IMAGE=${NIC_OPERATOR_HARBOR_IMAGE:-${HARBOR_REGESTRY}/${HARBOR_PROJECT}/network-operator}
 
 export OFED_DRIVER_IMAGE=${OFED_DRIVER_IMAGE:-'mofed'}
-export OFED_DRIVER_REPO=${OFED_DRIVER_REPO:-'harbor.mellanox.com/cloud-orchestration'}
-export OFED_DRIVER_VERSION=${OFED_DRIVER_VERSION:-'5.0-2.1.8.0'}
+export OFED_DRIVER_REPO=${OFED_DRIVER_REPO:-'harbor.mellanox.com/sw-linux-devops'}
+export OFED_DRIVER_VERSION=${OFED_DRIVER_VERSION:-'5.2-0.5.7.0'}
 
 export DEVICE_PLUGIN_IMAGE=${DEVICE_PLUGIN_IMAGE:-'k8s-rdma-shared-device-plugin'}
 export DEVICE_PLUGIN_REPO=${DEVICE_PLUGIN_REPO:-'harbor.mellanox.com/cloud-orchestration'}

--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -102,6 +102,8 @@ function test_deleting_network_operator {
 function test_rdma_only {
     status=0
 
+    sudo apt-get install -y rdma-core
+
     load_core_drivers
     sleep 2
 
@@ -154,6 +156,8 @@ function configure_common {
 
 function configure_ofed {
     local file_name="$1"
+
+    sudo apt-get purge -y rdma-core
 
     modprobe -r rpcrdma
 
@@ -353,7 +357,7 @@ function test_probes {
 
     sleep 10
 
-    local modules_list="mlx5_fpga_tools mlx5_ib mlx5_core"
+    local modules_list="mlx5_ib mlx5_core"
 
     echo "Testing Probes..."
     echo "Unloading ofed modules..."

--- a/nic_operator_helm/nic_operator_helm_ci_start.sh
+++ b/nic_operator_helm/nic_operator_helm_ci_start.sh
@@ -81,6 +81,8 @@ function deploy_operator {
 
     pushd $WORKSPACE/mellanox-network-operator
 
+    sudo apt-get purge -y rdma-core
+
     helm install -f $values_file \
         -n $NIC_OPERATOR_NAMESPACE \
         --create-namespace \


### PR DESCRIPTION
Changed the mofed image version to 5.2-0.5.7.0 from 5.0 and made
the necessary changes to make it work by uninstalling the rdma-core
package for any test that runs the ofed, and install it for tests
that run rdma tests only.