### PR TITLE
Redeploy the multus daemonset after the secondary network test

### DIFF
--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -64,10 +64,10 @@ create_workspace(){
 }
 
 get_arch(){
-    echo "Get CPU architechture"
-    export ARCH="amd"
     if [[ $(uname -a) == *"ppc"* ]]; then
-        export ARCH="ppc"
+        echo ppc
+    else
+        echo amd
     fi
 }
 
@@ -223,6 +223,7 @@ multus_install(){
 multus_configuration() {
     status=0
     echo "Configure Multus"
+    local arch=$(get_arch)
     date
     sleep 30
     sed -i 's;/etc/cni/net.d/multus.d/multus.kubeconfig;/etc/kubernetes/admin.conf;g' $WORKSPACE/multus-cni/images/multus-daemonset.yml
@@ -235,7 +236,7 @@ multus_configuration() {
     d=$(date '+%s')
     while [ $d -lt $stop ]; do
        echo "Wait until multus is ready"
-       ready=$(kubectl -n kube-system get ds |grep kube-multus-ds-${ARCH}|awk '{print $4}')
+       ready=$(kubectl -n kube-system get ds |grep kube-multus-ds-${arch}|awk '{print $4}')
        rc=$?
        kubectl -n kube-system get ds
        d=$(date '+%s')
@@ -247,7 +248,7 @@ multus_configuration() {
     done
     if [ $d -gt $stop ]; then
         kubectl -n kube-system get ds
-        echo "kube-multus-ds-${ARCH}64 is not ready in $TIMEOUT sec"
+        echo "kube-multus-ds-${arch}64 is not ready in $TIMEOUT sec"
         return 1
     fi
 

--- a/ipoib/ipoib_ci_start.sh
+++ b/ipoib/ipoib_ci_start.sh
@@ -51,8 +51,6 @@ function download_and_build {
 
 create_workspace
 
-get_arch
-
 cp ./ipoib/yaml/k8s-rdma-shared-device-plugin-configmap.yaml ${ARTIFACTS}/
 
 pushd $WORKSPACE

--- a/nic_operator/nic_operator_ci_start.sh
+++ b/nic_operator/nic_operator_ci_start.sh
@@ -113,12 +113,6 @@ function patch_pod_cider_to_node {
 function main {
     create_workspace
 
-    echo "Get CPU architechture"
-    export ARCH="amd"
-    if [[ $(uname -a) == *"ppc"* ]]; then
-       export ARCH="ppc"
-    fi
-
     cp ./deploy/macvlan-net.yaml "$ARTIFACTS"/
     cp ./nic_operator/yaml/* "$ARTIFACTS"/
 

--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -251,6 +251,7 @@ function test_secondary_network {
     status=0
     local sample_file="$ARTIFACTS"/seconday-network-nic-cluster-policy.yaml
     local multus_file="$WORKSPACE/multus-cni/images/multus-daemonset.yml"
+    local macvlan_bin="$WORKSPACE/plugins/bin/macvlan"
 
     echo ""
     echo "Testing Secondary networks..."
@@ -322,6 +323,16 @@ function test_secondary_network {
         echo "Error: Couldn't delete $sample_file!"
         return $status
     fi
+
+    # Note(abdallahyas): Redeploy the multus in the system to bring
+    # back the secondary network capabilities to the system.
+
+    multus_configuration
+
+    cp "$macvlan_bin" "$CNI_BIN_DIR"/
+
+    create_macvlan_net
+
     return 0
 
 }

--- a/nic_operator_helm/nic_operator_helm_ci_start.sh
+++ b/nic_operator_helm/nic_operator_helm_ci_start.sh
@@ -101,12 +101,6 @@ function deploy_operator {
 function main {
     create_workspace
 
-    echo "Get CPU architechture"
-    export ARCH="amd"
-    if [[ $(uname -a) == *"ppc"* ]]; then
-       export ARCH="ppc"
-    fi
-
     load_core_drivers
     rm -f /etc/cni/net.d/00*
 

--- a/sriov/sriov_ci_start.sh
+++ b/sriov/sriov_ci_start.sh
@@ -133,8 +133,6 @@ function create_vfs {
 
 create_workspace
 
-get_arch
-
 pushd $WORKSPACE
 
 load_rdma_modules

--- a/sriov_antrea/sriov_antrea_ci_start.sh
+++ b/sriov_antrea/sriov_antrea_ci_start.sh
@@ -131,8 +131,6 @@ function create_vfs {
 
 create_workspace
 
-get_arch
-
 create_vfs
 
 pushd $WORKSPACE

--- a/sriov_ib/sriov_ib_ci_start.sh
+++ b/sriov_ib/sriov_ib_ci_start.sh
@@ -130,8 +130,6 @@ fi
 
 create_workspace 
 
-get_arch
-
 pushd $WORKSPACE
 
 load_rdma_modules


### PR DESCRIPTION
Redeploy the multus daemonset to restore the CNI confs to how they
were before the secondary network test is performed. This is needed
since the network operator multus does not have permissions to modify
old deployed pods CNI interfaces, this prevents the kubelet from deleting
any already deployed pod before the test was performed (e.g. the network
operator pod). This also will make it possible to do more tests after this
test, since it will restore the deployment to its original state.