### PR TITLE
Clone Kubernetes using `git clone` instead of `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ The projects use environment variables to configure their components. Each proje
 |PLUGINS_REPO | https://github.com/containernetworking/plugins.git | containernetworking repo URL |
 |PLUGINS_BRANCH | master | containernetworking branch to build |
 |PLUGINS_BRANCH_PR || containernetworking cni pr to pull, if this is used the PLUGINS_BRANCH is ignored |
-|GOPATH | ${WORKSPACE} ||
 |PATH | /usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$PATH ||
 |CNI_BIN_DIR | /opt/cni/bin/ | this is used to configure Kubernetes local_cluser_up.sh CNI_BIN_DIR |
 |CNI_CONF_DIR | /etc/cni/net.d/ | this is used to configure Kubernetes local_cluser_up.sh CNI_CONF_DIR |

--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -28,7 +28,6 @@ export PLUGINS_REPO=${PLUGINS_REPO:-https://github.com/containernetworking/plugi
 export PLUGINS_BRANCH=${PLUGINS_BRANCH:-''}
 export PLUGINS_BRANCH_PR=${PLUGINS_BRANCH_PR:-''}
 
-export GOPATH=${WORKSPACE}
 export PATH=/usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$PATH
 
 export API_HOST=$(hostname)
@@ -78,11 +77,11 @@ k8s_build(){
     if [ ${KUBERNETES_VERSION} == 'latest_stable' ]; then
         export KUBERNETES_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
     fi
-    rm -rf $GOPATH/src/k8s.io/kubernetes
+    rm -rf $WORKSPACE/src/k8s.io/kubernetes
 
-    go get -d k8s.io/kubernetes
+    git clone https://github.com/kubernetes/kubernetes.git $WORKSPACE/src/k8s.io/kubernetes
 
-    pushd $GOPATH/src/k8s.io/kubernetes
+    pushd $WORKSPACE/src/k8s.io/kubernetes
     git checkout ${KUBERNETES_VERSION}
     git log -p -1 > $ARTIFACTS/kubernetes.txt
 
@@ -108,22 +107,6 @@ k8s_build(){
     let status=status+$?
     if [ "$status" != 0 ]; then
         echo "Failed to run kubectl please fix the error above!"
-        return $status
-    fi
-
-    go get -u github.com/tools/godep
-
-    let status=status+$?
-    if [ "$status" != 0 ]; then
-        echo "Failed to clone godep"
-        return $status
-    fi
-
-    go get -u github.com/cloudflare/cfssl/cmd/...
-
-    let status=status+$?
-    if [ "$status" != 0 ]; then
-        echo 'Failed to clone github.com/cloudflare/cfssl/cmd/...'
         return $status
     fi
 


### PR DESCRIPTION
Switch to cloning Kubernetes using `git clone` instead of using
`go get` since the `go get` command fails to clone because of mod
initializing issues on some systems.