### PR TITLE
Fix multus daemonset rename

### DIFF
--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -199,7 +199,7 @@ multus_install(){
     status=0
     build_github_project "multus-cni" "docker build -t $MULTUS_CNI_HARBOR_IMAGE ."
 
-    change_k8s_resource "DaemonSet" "kube-multus-ds-amd64" "spec.template.spec.containers[0].image"\
+    change_k8s_resource "DaemonSet" "kube-multus-ds" "spec.template.spec.containers[0].image"\
         "$MULTUS_CNI_HARBOR_IMAGE" "$WORKSPACE/multus-cni/images/multus-daemonset.yml"
 }
 
@@ -219,7 +219,7 @@ multus_configuration() {
     d=$(date '+%s')
     while [ $d -lt $stop ]; do
        echo "Wait until multus is ready"
-       ready=$(kubectl -n kube-system get ds |grep kube-multus-ds-${arch}|awk '{print $4}')
+       ready=$(kubectl -n kube-system get ds |grep kube-multus-ds|awk '{print $4}')
        rc=$?
        kubectl -n kube-system get ds
        d=$(date '+%s')


### PR DESCRIPTION
Latest master multus changes the daemonset name to `kube-multus-ds`
instead of `kube-multus-ds-amd64`. Since we look for that name to
change the image to use the harbor image, the CIs started to fail.
This patch modify the name of the daemonset to match the new name.