### PR TITLE
Use the helm values to determine the nic-cluster-policy images

### DIFF
--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -122,6 +122,10 @@ get_distro(){
     grep ^NAME= /etc/os-release | cut -d'=' -f2 -s | tr -d '"' | tr [:upper:] [:lower:] | cut -d" " -f 1
 }
 
+get_distro_version(){
+    grep ^VERSION_ID= /etc/os-release | cut -d'=' -f2 -s | tr -d '"'
+}
+
 configure_firewall(){
     local os_distro=$(get_distro)
     if [[ "$os_distro" == "ubuntu" ]];then

--- a/common/nic_operator_common.sh
+++ b/common/nic_operator_common.sh
@@ -15,39 +15,40 @@ export MACVLAN_NETWORK_DEFAULT_NAME=${MACVLAN_NETWORK_DEFAULT_NAME:-'example-mac
 export nic_operator_dir=$WORKSPACE/mellanox-network-operator/
 export NIC_OPERATOR_NAMESPACE_FILE=${NIC_OPERATOR_NAMESPACE_FILE:-"$nic_operator_dir/deploy/operator-ns.yaml"}
 export NIC_OPERATOR_RESOURCES_NAMESPACE_FILE=${NIC_OPERATOR_RESOURCES_NAMESPACE_FILE:-"$nic_operator_dir/deploy/operator-resources-ns.yaml"}
+export IMAGES_SRC_FILE="$nic_operator_dir/deployment/network-operator/values.yaml"
 
 export NIC_OPERATOR_REPO=${NIC_OPERATOR_REPO:-https://github.com/Mellanox/network-operator}
 export NIC_OPERATOR_BRANCH=${NIC_OPERATOR_BRANCH:-''}
 export NIC_OPERATOR_PR=${NIC_OPERATOR_PR:-''}
 export NIC_OPERATOR_HARBOR_IMAGE=${NIC_OPERATOR_HARBOR_IMAGE:-${HARBOR_REGESTRY}/${HARBOR_PROJECT}/network-operator}
 
-export OFED_DRIVER_IMAGE=${OFED_DRIVER_IMAGE:-'mofed'}
-export OFED_DRIVER_REPO=${OFED_DRIVER_REPO:-'harbor.mellanox.com/sw-linux-devops'}
-export OFED_DRIVER_VERSION=${OFED_DRIVER_VERSION:-'5.2-0.5.7.0'}
+export OFED_DRIVER_IMAGE=${OFED_DRIVER_IMAGE:-''}
+export OFED_DRIVER_REPO=${OFED_DRIVER_REPO:-''}
+export OFED_DRIVER_VERSION=${OFED_DRIVER_VERSION:-''}
 
-export DEVICE_PLUGIN_IMAGE=${DEVICE_PLUGIN_IMAGE:-'k8s-rdma-shared-device-plugin'}
-export DEVICE_PLUGIN_REPO=${DEVICE_PLUGIN_REPO:-'harbor.mellanox.com/cloud-orchestration'}
-export DEVICE_PLUGIN_VERSION=${DEVICE_PLUGIN_VERSION:-'latest'}
+export DEVICE_PLUGIN_IMAGE=${DEVICE_PLUGIN_IMAGE:-''}
+export DEVICE_PLUGIN_REPO=${DEVICE_PLUGIN_REPO:-''}
+export DEVICE_PLUGIN_VERSION=${DEVICE_PLUGIN_VERSION:-''}
 
-export RDMA_SHARED_DEVICE_PLUGIN_IMAGE=${RDMA_SHARED_DEVICE_PLUGIN_IMAGE:-'k8s-rdma-shared-device-plugin'}
-export RDMA_SHARED_DEVICE_PLUGIN_REPO=${RDMA_SHARED_DEVICE_PLUGIN_REPO:-'harbor.mellanox.com/cloud-orchestration'}
-export RDMA_SHARED_DEVICE_PLUGIN_VERSION=${RDMA_SHARED_DEVICE_PLUGIN_VERSION:-'latest'}
+export RDMA_SHARED_DEVICE_PLUGIN_IMAGE=${RDMA_SHARED_DEVICE_PLUGIN_IMAGE:-''}
+export RDMA_SHARED_DEVICE_PLUGIN_REPO=${RDMA_SHARED_DEVICE_PLUGIN_REPO:-''}
+export RDMA_SHARED_DEVICE_PLUGIN_VERSION=${RDMA_SHARED_DEVICE_PLUGIN_VERSION:-''}
 
-export NV_PEER_DRIVER_IMAGE=${NV_PEER_DRIVER_IMAGE:-'nv-peer-mem-driver'}
-export NV_PEER_DRIVER_REPO=${NV_PEER_DRIVER_REPO:-'harbor.mellanox.com/cloud-orchestration'}
-export NV_PEER_DRIVER_VERSION=${NV_PEER_DRIVER_VERSION:-'1.0-9'}
+export NV_PEER_DRIVER_IMAGE=${NV_PEER_DRIVER_IMAGE:-''}
+export NV_PEER_DRIVER_REPO=${NV_PEER_DRIVER_REPO:-''}
+export NV_PEER_DRIVER_VERSION=${NV_PEER_DRIVER_VERSION:-''}
 
-export SECONDARY_NETWORK_MULTUS_IMAGE=${SECONDARY_NETWORK_MULTUS_IMAGE:-'multus'}
-export SECONDARY_NETWORK_MULTUS_REPO=${SECONDARY_NETWORK_MULTUS_REPO:-'harbor.mellanox.com/cloud-orchestration'}
-export SECONDARY_NETWORK_MULTUS_VERSION=${SECONDARY_NETWORK_MULTUS_VERSION:-'latest'}
+export SECONDARY_NETWORK_MULTUS_IMAGE=${SECONDARY_NETWORK_MULTUS_IMAGE:-''}
+export SECONDARY_NETWORK_MULTUS_REPO=${SECONDARY_NETWORK_MULTUS_REPO:-''}
+export SECONDARY_NETWORK_MULTUS_VERSION=${SECONDARY_NETWORK_MULTUS_VERSION:-''}
 
-export SECONDARY_NETWORK_CNI_PLUGINS_IMAGE=${SECONDARY_NETWORK_CNI_PLUGINS_IMAGE:-'containernetworking-plugins'}
-export SECONDARY_NETWORK_CNI_PLUGINS_REPO=${SECONDARY_NETWORK_CNI_PLUGINS_REPO:-'harbor.mellanox.com/cloud-orchestration'}
-export SECONDARY_NETWORK_CNI_PLUGINS_VERSION=${SECONDARY_NETWORK_CNI_PLUGINS_VERSION:-'latest'}
+export SECONDARY_NETWORK_CNI_PLUGINS_IMAGE=${SECONDARY_NETWORK_CNI_PLUGINS_IMAGE:-''}
+export SECONDARY_NETWORK_CNI_PLUGINS_REPO=${SECONDARY_NETWORK_CNI_PLUGINS_REPO:-''}
+export SECONDARY_NETWORK_CNI_PLUGINS_VERSION=${SECONDARY_NETWORK_CNI_PLUGINS_VERSION:-''}
 
-export SECONDARY_NETWORK_IPAM_PLUGIN_IMAGE=${SECONDARY_NETWORK_IPAM_PLUGIN_IMAGE:-'whereabouts'}
-export SECONDARY_NETWORK_IPAM_PLUGIN_REPO=${SECONDARY_NETWORK_IPAM_PLUGIN_REPO:-'harbor.mellanox.com/cloud-orchestration'}
-export SECONDARY_NETWORK_IPAM_PLUGIN_VERSION=${SECONDARY_NETWORK_IPAM_PLUGIN_VERSION:-'latest'}
+export SECONDARY_NETWORK_IPAM_PLUGIN_IMAGE=${SECONDARY_NETWORK_IPAM_PLUGIN_IMAGE:-''}
+export SECONDARY_NETWORK_IPAM_PLUGIN_REPO=${SECONDARY_NETWORK_IPAM_PLUGIN_REPO:-''}
+export SECONDARY_NETWORK_IPAM_PLUGIN_VERSION=${SECONDARY_NETWORK_IPAM_PLUGIN_VERSION:-''}
 
 export NIC_OPERATOR_HELM_NAME=${NIC_OPERATOR_HELM_NAME:-'network-operator-helm-ci'}
 export NIC_OPERATOR_CRD_NAME=${NIC_OPERATOR_CRD_NAME:-'nicclusterpolicies.mellanox.com'}
@@ -287,3 +288,87 @@ sources:
 " "$file"
 }
 
+function pull_general_component_image {
+    local component_key="$1"
+    local file="$2"
+
+    local image_repo=$(yaml_read "${component_key}.repository" "$file")
+    local image_name=$(yaml_read "${component_key}.image" "$file")
+    local image_tag=$(yaml_read "${component_key}.version" "$file")
+
+    local image="${image_repo}/${image_name}:${image_tag}"
+
+    docker pull $image
+}
+
+function pull_ofed_container_image {
+    local mofed_key="$1"
+    local file="$2"
+
+    local image_repo=$(yaml_read "${mofed_key}.repository" "$file")
+    local image_name=$(yaml_read "${mofed_key}.image" "$file")
+    local image_version=$(yaml_read "${mofed_key}.version" "$file")
+
+    local image="${image_repo}/${image_name}-${image_version}:$(get_distro)$(get_distro_version)-amd64"
+
+    docker pull $image
+}
+
+function pull_nvpeer_container_image {
+    local nvpeer_key="$1"
+    local file="$2"
+
+    local image_repo=$(yaml_read "${nvpeer_key}.repository" "$file")
+    local image_name=$(yaml_read "${nvpeer_key}.image" "$file")
+    local image_version=$(yaml_read "${nvpeer_key}.version" "$file")
+
+    local image="${image_repo}/${image_name}-${image_version}:amd64-$(get_distro)$(get_distro_version)"
+
+    docker pull $image
+}
+
+function pull_network_operator_images {
+    pull_ofed_container_image "ofedDriver" "$IMAGES_SRC_FILE"
+
+    pull_general_component_image "rdmaSharedDevicePlugin" "$IMAGES_SRC_FILE"
+
+    pull_nvpeer_container_image "nvPeerDriver" "$IMAGES_SRC_FILE"
+
+    pull_general_component_image "secondaryNetwork.cniPlugins" "$IMAGES_SRC_FILE"
+
+    pull_general_component_image "secondaryNetwork.multus" "$IMAGES_SRC_FILE"
+
+    pull_general_component_image "secondaryNetwork.ipamPlugin" "$IMAGES_SRC_FILE"
+}
+
+function configure_images_variable {
+    local key="$1"
+
+    local image="$(yaml_read "${key}.image" "$IMAGES_SRC_FILE")"
+    local repo="$(yaml_read "${key}.repository" "$IMAGES_SRC_FILE")"
+    local version="$(yaml_read "${key}.version" "$IMAGES_SRC_FILE")"
+
+    local upper_case_key="$(sed 's/[A-Z]/\.\0/g' <<< $key | tr "." "_" | tr '[:lower:]' '[:upper:]')"
+
+    local image_variable="${upper_case_key}_IMAGE"
+    local repo_variable="${upper_case_key}_REPO"
+    local version_variable="${upper_case_key}_VERSION"
+
+    export ${image_variable}="$image"
+    export ${repo_variable}="$repo"
+    export ${version_variable}="$version"
+}
+
+function set_network_operator_images_variables {
+    configure_images_variable "ofedDriver"
+
+    configure_images_variable "rdmaSharedDevicePlugin"
+
+    configure_images_variable "nvPeerDriver"
+
+    configure_images_variable "secondaryNetwork.cniPlugins"
+
+    configure_images_variable "secondaryNetwork.multus"
+
+    configure_images_variable "secondaryNetwork.ipamPlugin"
+}

--- a/nic_operator/nic_operator_ci_start.sh
+++ b/nic_operator/nic_operator_ci_start.sh
@@ -28,7 +28,12 @@ function download_and_build {
     [ -d /var/lib/cni/sriov ] && rm -rf /var/lib/cni/sriov/*
 
     build_nic_operator_image
-    return $?
+    let status=status+$?
+
+    pull_network_operator_images
+    let status=status+$?
+
+    return $status
 }
 
 function configure_namespace {

--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -518,6 +518,8 @@ function main {
         export SRIOV_INTERFACE=$(ls -l /sys/class/net/ | grep $(lspci |grep Mellanox | grep -Ev 'MT27500|MT27520' | head -n1 | awk '{print $1}') | awk '{print $9}')
     fi
 
+    set_network_operator_images_variables
+
     test_ofed_only
     let status=status+$?
     if [ "$status" != 0 ]; then

--- a/nic_operator_helm/nic_operator_helm_ci_start.sh
+++ b/nic_operator_helm/nic_operator_helm_ci_start.sh
@@ -26,7 +26,14 @@ function download_and_build {
     [ -d /var/lib/cni/sriov ] && rm -rf /var/lib/cni/sriov/*
 
     build_nic_operator_image
-    return $?
+    let status=$status+$?
+
+    pull_network_operator_images
+    let status=$status+$?
+
+    set_network_operator_images_variables
+
+    return $status
 }
 
 function configure_helm_values {
@@ -55,9 +62,9 @@ function configure_helm_values {
     fi
 
     yaml_write "$rdma_shared_device_plugin_key".deploy "true" $file_name
-    yaml_write "$rdma_shared_device_plugin_key".image "$DEVICE_PLUGIN_IMAGE" $file_name
-    yaml_write "$rdma_shared_device_plugin_key".repository "$DEVICE_PLUGIN_REPO" $file_name
-    yaml_write "$rdma_shared_device_plugin_key".version "$DEVICE_PLUGIN_VERSION" $file_name
+    yaml_write "$rdma_shared_device_plugin_key".image "$RDMA_SHARED_DEVICE_PLUGIN_IMAGE" $file_name
+    yaml_write "$rdma_shared_device_plugin_key".repository "$RDMA_SHARED_DEVICE_PLUGIN_REPO" $file_name
+    yaml_write "$rdma_shared_device_plugin_key".version "$RDMA_SHARED_DEVICE_PLUGIN_VERSION" $file_name
 
     yaml_write "$rdma_shared_device_plugin_key".resources[0].name "rdma_shared_devices_a" $file_name
     yaml_write "$rdma_shared_device_plugin_key".resources[0].ifNames[0] "$SRIOV_INTERFACE" $file_name


### PR DESCRIPTION
This patch configures the tested nic-cluster-policy in the network
operator projects to match the helm values in the repo instead of
them being hard coded. It does so in two steps:
- It pulls the images manually to avoid the dockerhub pull limit issue

  ```
  note
  The CI machine must be logged in to a dockerhub account
  ```

- It configures the global environment variables responsible for the images