### PR TITLE
Fix the network operator helm deployment check

### DIFF
--- a/nic_operator_helm/nic_operator_helm_ci_start.sh
+++ b/nic_operator_helm/nic_operator_helm_ci_start.sh
@@ -95,6 +95,18 @@ function deploy_operator {
         ${NIC_OPERATOR_HELM_NAME} \
         ./deployment/network-operator/
 
+    wait_pod_state "${NIC_OPERATOR_HELM_NAME}" "Running"
+    let status=$status+$?
+    if [ "$status" != 0 ]; then
+        echo "ERROR: Timeout waiting for ${NIC_OPERATOR_HELM_NAME} to become running!!"
+        popd
+        return $status
+    fi
+
+    sleep 5
+
+    unlabel_master
+
     wait_nic_policy_states "" "state-ofed"
     if [ "$?" != 0 ]; then
         echo "Timed out waiting for operator to become running"

--- a/nic_operator_helm/nic_operator_helm_ci_start.sh
+++ b/nic_operator_helm/nic_operator_helm_ci_start.sh
@@ -94,6 +94,12 @@ function deploy_operator {
         --create-namespace \
         ${NIC_OPERATOR_HELM_NAME} \
         ./deployment/network-operator/
+    let status=$status+$?
+    if [ "$status" != 0 ]; then
+        echo "Failed to install the network operator using helm"
+        popd
+        return $status
+    fi
 
     wait_pod_state "${NIC_OPERATOR_HELM_NAME}" "Running"
     let status=$status+$?
@@ -108,7 +114,8 @@ function deploy_operator {
     unlabel_master
 
     wait_nic_policy_states "" "state-ofed"
-    if [ "$?" != 0 ]; then
+    let status=$status+$?
+    if [ "$status" != 0 ]; then
         echo "Timed out waiting for operator to become running"
         popd
         return $status


### PR DESCRIPTION
The network operator helm deployment check returns a wrong return
status due to a typo, this patch fix that, and adds an additional
check for the deployment in addition to the check for the operator
to become running.