### PR TITLE
Fix usage of 'yq' binary

### DIFF
--- a/nic_operator_helm/nic_operator_helm_ci_start.sh
+++ b/nic_operator_helm/nic_operator_helm_ci_start.sh
@@ -98,7 +98,14 @@ function deploy_operator {
 
     # Install charts from 3rd-party repositories. Errors for empty reposetories won't affect installation.
     cd deployment/network-operator
-    yq '.dependencies[] | "\(.name) \(.repository)"'  Chart.yaml |  tr -d '"' | xargs -t  -L 1 helm repo add
+    local charts=$(yq r Chart.yaml dependencies  -l)
+    for index in $(seq 0 "$charts"); do
+        local chart=$(yq r Chart.yaml dependencies[$index].name)
+        local repo=$(yq r Chart.yaml dependencies[$index].repository)
+        if [[ ! -z "$repo" ]]; then
+                helm repo add $chart $repo
+        fi
+    done
 
     helm repo update
     helm dependency build

--- a/prepare_setup.sh
+++ b/prepare_setup.sh
@@ -4,7 +4,7 @@ go_version=""
 
 go_dir=/usr/local
 
-helm_version="v3.4.0"
+helm_version="v3.5.3"
 helm_package_dir_name='helm'
 
 ##################################################


### PR DESCRIPTION
Commit 56493fb43566138490e8b61be81cec4594f87afe uses incorrect
version of the 'jq'. This commit fixes it.