### PR TITLE
Kind ansible CI

### DIFF
--- a/ansible/deploy-kind.yaml
+++ b/ansible/deploy-kind.yaml
@@ -1,0 +1,7 @@
+---
+- name: Deploy Kind Cluster
+  hosts: kind_nodes
+  become: true
+  remote_user: root
+  roles:
+    - kind/kind_install

--- a/ansible/deploy-kind.yaml
+++ b/ansible/deploy-kind.yaml
@@ -5,3 +5,4 @@
   remote_user: root
   roles:
     - kind/kind_install
+    - kind/kind_cluster_create

--- a/ansible/group_vars/kind_nodes.yaml
+++ b/ansible/group_vars/kind_nodes.yaml
@@ -1,3 +1,6 @@
 project: "{{ lookup('env', 'PROJECT') }}"
 workspace: "{{ lookup('env', 'WORKSPACE') }}"
 artifacts: "{{ workspace+ '/artifacts' }}"
+num_worker: "{{ lookup('env', 'KIND_NUM_WORKER') }}"
+kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+kind_config: "{{ lookup('env', 'KIND_CONFIG') }}"

--- a/ansible/group_vars/kind_nodes.yaml
+++ b/ansible/group_vars/kind_nodes.yaml
@@ -1,0 +1,3 @@
+project: "{{ lookup('env', 'PROJECT') }}"
+workspace: "{{ lookup('env', 'WORKSPACE') }}"
+artifacts: "{{ workspace+ '/artifacts' }}"

--- a/ansible/inventory/hosts
+++ b/ansible/inventory/hosts
@@ -1,0 +1,2 @@
+[kind_nodes]
+localhost ansible_connection=local

--- a/ansible/prepare-ci-environment.yaml
+++ b/ansible/prepare-ci-environment.yaml
@@ -1,0 +1,7 @@
+---
+- name: Prepare CI cluster environment
+  hosts: kind_nodes
+  become: true
+  remote_user: root
+  roles:
+    - prepare-ci-environment

--- a/ansible/roles/kind/kind_cluster_create/handlers/main.yml
+++ b/ansible/roles/kind/kind_cluster_create/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for kind_cluster_create

--- a/ansible/roles/kind/kind_cluster_create/tasks/main.yml
+++ b/ansible/roles/kind/kind_cluster_create/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Render kind config
+  block:
+    - name: create temporary directory to render kind configuration
+      tempfile:
+        state: directory
+        suffix: build
+      register: kind_conf_temp_dir
+    - set_fact:
+        kind_rendered_config: "{{kind_conf_temp_dir.path}}/kind.yaml"
+    - name: Render kind configuration
+      template:
+        src: kind.yaml.j2
+        dest: "{{kind_rendered_config}}"
+    - name: Copy rendered kind configuration to artifacts
+      copy:
+        src: "{{kind_rendered_config}}"
+        dest: "{{artifacts}}/kind.yaml"
+    - set_fact:
+        kind_config: "{{kind_rendered_config}}"
+  when: 'kind_config == ""'
+- name: Deploy Kind cluster {{project}}
+  command:
+    cmd: kind create cluster --name {{project}} --kubeconfig {{kubeconfig}} --config {{kind_config}}

--- a/ansible/roles/kind/kind_cluster_create/templates/kind.yaml.j2
+++ b/ansible/roles/kind/kind_cluster_create/templates/kind.yaml.j2
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+ - role: control-plane
+
+{%- for _ in range(num_worker | int) %}
+
+ - role: worker
+{%- endfor %}

--- a/ansible/roles/kind/kind_cluster_create/vars/main.yml
+++ b/ansible/roles/kind/kind_cluster_create/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for kind_install

--- a/ansible/roles/kind/kind_cluster_destroy/handlers/main.yml
+++ b/ansible/roles/kind/kind_cluster_destroy/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for kind_cluster_destroy

--- a/ansible/roles/kind/kind_cluster_destroy/tasks/main.yml
+++ b/ansible/roles/kind/kind_cluster_destroy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Destroy Kind cluster
+  command:
+    cmd: kind delete cluster --name {{project}}

--- a/ansible/roles/kind/kind_cluster_destroy/vars/main.yml
+++ b/ansible/roles/kind/kind_cluster_destroy/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for kind_cluster_destroy

--- a/ansible/roles/kind/kind_install/handlers/main.yml
+++ b/ansible/roles/kind/kind_install/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for kind_install

--- a/ansible/roles/kind/kind_install/tasks/main.yml
+++ b/ansible/roles/kind/kind_install/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Query local Kind version
+  command:
+    cmd: kind version -q
+  ignore_errors: true
+  register: kind_version
+- name: Query upstream latest Kind version
+  uri:
+    url: https://api.github.com/repos/kubernetes-sigs/kind/releases/latest
+    status_code: 200
+    body_format: json
+  ignore_errors: true
+  register: kind_latest_release
+- name: Install/Update Kind to latest release
+  block:
+    - get_url:
+        url: https://github.com/kubernetes-sigs/kind/releases/download/{{kind_latest_release.json.name}}/kind-linux-amd64
+        dest: /usr/local/bin/kind
+        mode: "555"
+    - command:
+        cmd: kind --version
+      register: new_kind_version
+    - debug:
+        var: new_kind_version.stdout
+  when: "kind_version is failed or kind_version.stdout is version(kind_latest_release.json.name[1:], '<')"

--- a/ansible/roles/kind/kind_install/vars/main.yml
+++ b/ansible/roles/kind/kind_install/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for kind_install

--- a/ansible/roles/prepare-ci-environment/handlers/main.yml
+++ b/ansible/roles/prepare-ci-environment/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for prepare-ci-environment

--- a/ansible/roles/prepare-ci-environment/tasks/main.yml
+++ b/ansible/roles/prepare-ci-environment/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Clean workspace
+  file:
+    path: "{{workspace}}"
+    state: absent
+- name: Create workspace directory
+  file:
+    path: "{{workspace}}"
+    state: directory
+- name: Create artifacts directory
+  file:
+    path: "{{artifacts}}"
+    state: directory

--- a/ansible/roles/prepare-ci-environment/vars/main.yml
+++ b/ansible/roles/prepare-ci-environment/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for prepare-ci-environment

--- a/ansible/undeploy-kind.yaml
+++ b/ansible/undeploy-kind.yaml
@@ -1,0 +1,7 @@
+---
+- name: Destroy Kind Cluster
+  hosts: kind_nodes
+  become: true
+  remote_user: root
+  roles:
+    - kind/kind_cluster_destroy

--- a/prepare_setup.sh
+++ b/prepare_setup.sh
@@ -38,6 +38,7 @@ it do the following:
     - configure /etc/sysctl.conf
     - configure /etc/hosts
     - install yq
+    - install ansible
 
 options:
 
@@ -270,6 +271,16 @@ packages_install(){
     return $local_status
 }
 
+pip_packages_install(){
+    packages="ansible==3.2.0"
+
+    echo ""
+    echo "Installing pip packages $packages ...."
+
+    pip3 install -U pip setuptools
+    pip3 install $packages
+}
+
 main(){
     status=0
 
@@ -297,6 +308,9 @@ main(){
     let status=$status+$?
 
     packages_install
+    let status=$status+$?
+
+    pip_packages_install
     let status=$status+$?
 
     return $status

--- a/run_kind_ci.sh
+++ b/run_kind_ci.sh
@@ -5,7 +5,7 @@ set -e
 KIND_CI_PROJECTS=("sriov-cni" "sriov-ib" "antrea" "ipoib" "network-operator" "antrea")
 KIND_CI_PHASES=("prepare-ci-environment" "deploy-kind" "utilities" "deploy-project" "test" "undeploy-project" "undeploy-kind")
 # SUPPORTED_PHASES is temporally used until all phases are supported
-SUPPORTED_PHASES=("prepare-ci-environment")
+SUPPORTED_PHASES=("prepare-ci-environment" "deploy-kind")
 export PHASES_TO_RUN=("${SUPPORTED_PHASES[@]}")
 
 usage() {

--- a/run_kind_ci.sh
+++ b/run_kind_ci.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -e
+
+KIND_CI_PROJECTS=("sriov-cni" "sriov-ib" "antrea" "ipoib" "network-operator" "antrea")
+KIND_CI_PHASES=("prepare-ci-environment" "deploy-kind" "utilities" "deploy-project" "test" "undeploy-project" "undeploy-kind")
+# SUPPORTED_PHASES is temporally used until all phases are supported
+SUPPORTED_PHASES=("prepare-ci-environment")
+export PHASES_TO_RUN=("${SUPPORTED_PHASES[@]}")
+
+usage() {
+  echo "usage: run_kind_ci.sh [[--project <name>] [--skip-phases <phases>] [-h]]"
+  echo ""
+  echo "--project              Project to run CI: ${KIND_CI_PROJECTS[*]}"
+  echo "                       Required field"
+  echo "--skip-phases          Comma separated phases, phases: ${KIND_CI_PHASES[*]}"
+  echo ""
+}
+
+containsElement() {
+  local value="$1"
+  local list="$2"
+  shift
+  for e in $list; do
+    [[ "$e" == "$value" ]] && return 0
+  done
+
+  return 1
+}
+
+parse_skip_phases() {
+  SKIP_PHASES=$1
+  IFS="," read -a SKIP_PHASES <<<"$1"
+  for phase in "${SKIP_PHASES[@]}"; do
+    if ! containsElement "$phase" "${KIND_CI_PHASES[*]}"; then
+      echo "Unknown phase $phase"
+      usage
+      exit 1
+    fi
+  done
+
+  PHASES_TO_RUN=()
+  for phase in "${SUPPORTED_PHASES[@]}"; do
+    if ! containsElement "$phase" "${SKIP_PHASES[*]}"; then
+      PHASES_TO_RUN+=("$phase")
+    fi
+  done
+}
+
+parse_args() {
+  while [ "$1" != "" ]; do
+    case $1 in
+    --project)
+      shift
+      project=$1
+      containsElement "$project" "${KIND_CI_PROJECTS[*]}"
+      if [[ "$?" != "0" ]]; then
+        echo "Unknown project ci $project"
+        usage
+        exit 1
+      fi
+      export PROJECT=$project
+      ;;
+    --skip-phases)
+      shift
+      parse_skip_phases $1
+      ;;
+    -h | --help)
+      usage
+      exit
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+    esac
+    shift
+  done
+
+  # Required parameters
+  if [[ "$PROJECT" == "" ]]; then
+    echo "--project is required"
+    usage
+    exit 1
+  fi
+}
+
+set_default_params() {
+  # Set default values
+  export WORKSPACE=${WORKSPACE:-"/tmp/kind_ci/$PROJECT"}
+}
+
+print_params() {
+  echo "Using these parameters to KIND CI"
+  echo ""
+  echo "WORKSPACE       = ${WORKSPACE}"
+  echo "PHASES_TO_RUN   = ${PHASES_TO_RUN[*]}"
+  echo "PROJECT         = ${PROJECT}"
+  echo ""
+}
+
+parse_args "$@"
+set_default_params
+print_params
+for phase in "${PHASES_TO_RUN[@]}"; do
+  echo "=============================="
+  echo "Running phase $phase"
+  ansible-playbook --inventory ansible/inventory/hosts "ansible/$phase.yaml" -vv
+done
+
+echo "Finished running Kind CI"

--- a/run_kind_ci.sh
+++ b/run_kind_ci.sh
@@ -9,11 +9,16 @@ SUPPORTED_PHASES=("prepare-ci-environment" "deploy-kind")
 export PHASES_TO_RUN=("${SUPPORTED_PHASES[@]}")
 
 usage() {
-  echo "usage: run_kind_ci.sh [[--project <name>] [--skip-phases <phases>] [-h]]"
+  echo "usage: run_kind_ci.sh [[--project <name>] [--skip-phases <phases>] [--num-workers <num>]"
+  echo "                       [--kind-config <conf-fil>] [--kubeconfig <path>]  [-h]]"
   echo ""
   echo "--project              Project to run CI: ${KIND_CI_PROJECTS[*]}"
   echo "                       Required field"
   echo "--skip-phases          Comma separated phases, phases: ${KIND_CI_PHASES[*]}"
+  echo "--num-workers          Number of worker nodes. DEFAULT: 2 worker"
+  echo "--kind-config          Kind configuration file, if provided skip rendering related parameters"
+  echo "                       if provided, ignores rendering related parameters (num-workers)"
+  echo "--kubeconfig           KUBECONFIG for kind cluster"
   echo ""
 }
 
@@ -65,6 +70,29 @@ parse_args() {
       shift
       parse_skip_phases $1
       ;;
+    --num-workers)
+      shift
+      if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+        echo "Invalid num-workers: $1"
+        usage
+        exit 1
+      fi
+      export KIND_NUM_WORKER=$1
+      ;;
+    --kind-config)
+      shift
+      kind_conf=$1
+      if test ! -f "$kind_conf"; then
+        echo "$kind_conf does not  exist"
+        usage
+        exit 1
+      fi
+      export KIND_CONFIG=$1
+      ;;
+    --kubeconfig)
+      shift
+      export KUBECONFIG=$1
+      ;;
     -h | --help)
       usage
       exit
@@ -88,6 +116,8 @@ parse_args() {
 set_default_params() {
   # Set default values
   export WORKSPACE=${WORKSPACE:-"/tmp/kind_ci/$PROJECT"}
+  export KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
+  export KUBECONFIG=${KUBECONFIG:-$HOME/admin.conf}
 }
 
 print_params() {
@@ -96,6 +126,9 @@ print_params() {
   echo "WORKSPACE       = ${WORKSPACE}"
   echo "PHASES_TO_RUN   = ${PHASES_TO_RUN[*]}"
   echo "PROJECT         = ${PROJECT}"
+  echo "KIND_NUM_WORKER = ${KIND_NUM_WORKER}"
+  echo "KIND_CONFIG     = ${KIND_CONFIG}"
+  echo "KUBECONFIG      = ${KUBECONFIG}"
   echo ""
 }
 

--- a/run_kind_ci.sh
+++ b/run_kind_ci.sh
@@ -5,7 +5,7 @@ set -e
 KIND_CI_PROJECTS=("sriov-cni" "sriov-ib" "antrea" "ipoib" "network-operator" "antrea")
 KIND_CI_PHASES=("prepare-ci-environment" "deploy-kind" "utilities" "deploy-project" "test" "undeploy-project" "undeploy-kind")
 # SUPPORTED_PHASES is temporally used until all phases are supported
-SUPPORTED_PHASES=("prepare-ci-environment" "deploy-kind")
+SUPPORTED_PHASES=("prepare-ci-environment" "deploy-kind" "undeploy-kind")
 export PHASES_TO_RUN=("${SUPPORTED_PHASES[@]}")
 
 usage() {


### PR DESCRIPTION
This PR presents a new CI structure using kind and ansible

- Present new script run_kind_ci.sh to run CI using kind cluster 
- Divide CI into 7 phases ("prepare-ci-environment" "deploy-kind" "utilities" "deploy-project" "test" "undeploy-project" "undeploy-kind")
- Run each CI with its corresponding ansible play-book