### PR TITLE
Use nic-cluster-policy to configure multus in nic_operator CI

### DIFF
--- a/nic_operator/nic_operator_ci_start.sh
+++ b/nic_operator/nic_operator_ci_start.sh
@@ -148,18 +148,6 @@ function main {
         exit 1
     fi
 
-    deploy_multus
-    if [ $? -ne 0 ]; then
-        echo "Failed to deploy the multus cni"
-        exit 1
-    fi
-
-    create_macvlan_net
-    if [ $? -ne 0 ]; then
-        echo "Failed to create the macvlan net"
-        exit 1
-    fi
-
     download_and_build
     if [ $? -ne 0 ]; then
         echo "Failed to download and build components"
@@ -171,6 +159,11 @@ function main {
         echo "Failed to run the operator components"
         exit 1
     fi
+
+    unlabel_master
+
+    configure_macvlan_custom_resource "$ARTIFACTS/example-macvlan-cr.yaml"
+    kubectl create -f "$ARTIFACTS/example-macvlan-cr.yaml"
 
     echo "All code in $WORKSPACE"
     echo "All logs $LOGDIR"


### PR DESCRIPTION
Before this point, multus was manually deployed in the nic-operator
project, and only secondary network test used to use the secondary
network field of the nic-cluster-policy. This was the case since
the CI was scripted and before the secondary network feature was
added to the project.

As part of CI enhacment and to test all the operator component using
the seconady network, this patch deploys the seconadry network components
on all tests and remove the normal multus deployment from the nic-operator
scripts.
