### PR TITLE
Fix sriov operator CI jenkins integration issues

### DIFF
--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -886,7 +886,7 @@ function remount_workers_sys_fs {
     fi
 
     for worker_container in $worker_containers; do
-        sudo docker exec -it "$worker_container" mount -o remount,rw /sys
+        sudo docker exec -t "$worker_container" mount -o remount,rw /sys
         let status=$status+$?
     done
 

--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -854,6 +854,8 @@ function deploy_kind_cluster {
         return 1
     fi
 
+    chmod +r $KUBECONFIG
+
     if [[ "$workers_number" -ge '1' ]];then
         remount_workers_sys_fs
         let status=$status+$?

--- a/sriov_network_operator/sriov_network_operator_ci_start.sh
+++ b/sriov_network_operator/sriov_network_operator_ci_start.sh
@@ -25,7 +25,7 @@ export PATH=/usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$P
 
 export CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin/}
 export CNI_CONF_DIR=${CNI_CONF_DIR:-/etc/cni/net.d/}
-export KUBECONFIG='/root/.kube/config'
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 #TODO add autodiscovering
 export SRIOV_INTERFACE=${SRIOV_INTERFACE:-auto_detect}

--- a/sriov_network_operator/sriov_network_operator_ci_stop.sh
+++ b/sriov_network_operator/sriov_network_operator_ci_stop.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -x
 
+source ./common/clean_common.sh
+
 export LOGDIR=$WORKSPACE/logs
 export ARTIFACTS=$WORKSPACE/artifacts
 
-export KUBECONFIG='/root/.kube/config'
-
-source ./common/clean_common.sh
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 function clean_antrea_runtime {
     rm -rf /var/run/antrea/

--- a/sriov_network_operator/sriov_network_operator_ci_test.sh
+++ b/sriov_network_operator/sriov_network_operator_ci_test.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+source ./common/clean_common.sh
+
 export WORKSPACE=${WORKSPACE:-/tmp/k8s_$$}
 export LOGDIR=$WORKSPACE/logs
 export ARTIFACTS=$WORKSPACE/artifacts
 
-export KUBECONFIG='/root/.kube/config'
+export KUBECONFIG=${KUBECONFIG:-/etc/kubernetes/admin.conf}
 
 function exit_code {
     rc="$1"


### PR DESCRIPTION
Found two issues when integrating the CI with the jenkins:
* Jenkins would fail to run commands if the interactive flag of the docker exec command was used.
* CI user would fail to read hidden files in the `/root` directory even if read access is granted.

This PR fixes these two issues.