### PR TITLE
Make vf-switcher periodic interval configurable

### DIFF
--- a/deploy/vf-netns-switcher.sh
+++ b/deploy/vf-netns-switcher.sh
@@ -5,7 +5,7 @@ pf=""
 conf_file=""
 pci=""
 
-TIMEOUT="10"
+TIMEOUT="${TIMEOUT:-2}"
 POLL_INTERVAL="1"
 
 while test $# -gt 0; do


### PR DESCRIPTION
Make the vf-switcher periodic interval configurable by taking the
environment variable value if set. Also change the default timeout
to 2 seconds from 10 seconds.