### PR TITLE
Add support for using a per project environment file for ansible proj…

### DIFF
--- a/run_kind_ci.sh
+++ b/run_kind_ci.sh
@@ -157,6 +157,10 @@ parse_args() {
 }
 
 set_default_params() {
+  if [[ -e $ansible_dir/projects/$PROJECT/environment.sh ]];then
+    source $ansible_dir/projects/$PROJECT/environment.sh
+  fi
+
   # Set default values
   export WORKSPACE=${WORKSPACE:-"/tmp/kind_ci/$PROJECT"}
   export KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}


### PR DESCRIPTION
…ects

Added the ability to configure a per project environment.sh file
that would be sourced at the start of the run_kind_ci.sh. This is
done to be able to configure the default values of the run_kind_ci.sh
script per project. This is needed since some projects wont work as
expected with the run_kind_ci.sh default values, and changing that
can break other CIs.