### PR TITLE
Sriov operator restart config daemon before test

### DIFF
--- a/sriov_network_operator/sriov_network_operator_ci_test.sh
+++ b/sriov_network_operator/sriov_network_operator_ci_test.sh
@@ -19,6 +19,15 @@ function exit_code {
 function test_sriov_operator_e2e {
     pushd $WORKSPACE/sriov-network-operator
 
+    # TODO: Sometimes the config daemon fails to discover the card
+    # pfs, until the root cause is determined, deleting the
+    # the config daemon pod would solve the issue.
+
+    local config_daemon_info=$(kubectl get pods -A -l app=sriov-network-config-daemon | grep -v NAME)
+    kubectl delete pod -n $(awk '{print $1}' <<< $config_daemon_info)\
+        $(awk '{print $2}' <<< $config_daemon_info)
+
+
     make test-e2e-k8s
     let status=$status+$?
     if [ "$status" != 0 ]; then

--- a/sriov_network_operator/sriov_network_operator_ci_test.sh
+++ b/sriov_network_operator/sriov_network_operator_ci_test.sh
@@ -16,22 +16,32 @@ function exit_code {
     exit $rc
 }
 
-function main {
-    status=0
-
-    pushd $WORKSPACE/sriov-network-operator 
+function test_sriov_operator_e2e {
+    pushd $WORKSPACE/sriov-network-operator
 
     make test-e2e-k8s
-    let status=status+$?
+    let status=$status+$?
     if [ "$status" != 0 ]; then
         echo "Error: error in e2e testing!"
         popd
+        return $status
+    fi
+
+    popd
+}
+
+function main {
+    status=0
+
+    echo "all tests succeeded!!"
+
+    test_sriov_operator_e2e
+    let status=$status+$?
+    if [ "$status" != 0 ]; then
+        echo "Error: error testing SRIOV-operator!"
         exit_code $status
     fi
-    
-    echo "all tests succeeded!!"
-    
-    popd
+
     exit_code $status
 }
 


### PR DESCRIPTION
Sometimes, SRIOV operator E2E test fails because it fails to configure
VFs, debuging some more, it was observed that when that happens, the
SRIOV operator config daemon fails to discover the PFs of the machine.

This patch workaround that issue by restarting the SRIOV operator
config daemon so that it will rediscover the interfaces.