### PR TITLE
Add deviceID to hostdevice nic-selector filter for nic-operator tests

### DIFF
--- a/common/nic_operator_common.sh
+++ b/common/nic_operator_common.sh
@@ -487,6 +487,14 @@ function configure_host_device {
     local resource_prefix=${2:-'nvidia.com'}
     local resource_name=${3:-'hostdev'}
 
+    if [[ -n "$project" ]];then
+        local netns="${project}-worker"
+    else
+        local netns=""
+    fi
+
+    local pf_device_id=$(get_pf_device_id "$netns")
+
     configure_images_specs "sriovDevicePlugin" "$file_name"
 
     yaml_write spec.sriovDevicePlugin.config "\
@@ -497,7 +505,8 @@ function configure_host_device {
       \"resourceName\": \"$resource_name\",
       \"selectors\": {
         \"isRdma\": true,
-        \"drivers\": [\"mlx5_core\"]
+        \"drivers\": [\"mlx5_core\"],
+        \"devices\": [\"$pf_device_id\"]
       }
     }
   ]

--- a/nic_operator_kind/nic_operator_kind_ci_test.sh
+++ b/nic_operator_kind/nic_operator_kind_ci_test.sh
@@ -27,6 +27,8 @@ export CNI_BIN_DIR=${CNI_BIN_DIR:-'/opt/cni/bin'}
 
 test_pod_image='harbor.mellanox.com/cloud-orchestration/rping-test'
 
+project="nic-operator-kind"
+
 function exit_code {
     rc="$1"
     echo "All logs $LOGDIR"


### PR DESCRIPTION
Added the deviceID nic-selector filter to the hostdevice configuration
. This was done because the sriov-device-plugin is not namespace aware
which cause it to discover devices outside of the kind nodes namespace
and register them. This causes the nic-operator-kind project to fail
since the hostdevice CNI will fail to discover the device.