### PR TITLE
Pull the SRIOV device plugin image to not hit the pull rate limit

### DIFF
--- a/common/nic_operator_common.sh
+++ b/common/nic_operator_common.sh
@@ -395,6 +395,8 @@ function pull_network_operator_images {
     pull_general_component_image "secondaryNetwork.multus" "$IMAGES_SRC_FILE" "$kind_netns"
 
     pull_general_component_image "secondaryNetwork.ipamPlugin" "$IMAGES_SRC_FILE" "$kind_netns"
+
+    pull_general_component_image "sriovDevicePlugin" "$IMAGES_SRC_FILE" "$kind_netns"
 }
 
 function configure_images_variable {


### PR DESCRIPTION
For the network operator CIs, the sriov-device-plugin image is not
being pulled before the CI, this will apply the dockerhub pull rate
limit policy. This patch pulls the image so that it will not be
affected by dockerhub rate limit issue.