### PR TITLE
Filter out infniband interfaces for get_mlnx_interfaces role

### DIFF
--- a/ansible/ci_vars/kind_ci.yaml
+++ b/ansible/ci_vars/kind_ci.yaml
@@ -10,4 +10,5 @@ pull_request: "{{ lookup('env', 'PULL_REQUEST') }}"
 unsupported_interfaces_list: [ "0x4115", "0x1015" ]
 pod_subnet: "{{ lookup('env', 'POD_CIDER') }}"
 service_subnet: "{{ lookup('env', 'SERVICE_CIDER') }}"
+interfaces_type: "{{ lookup('env', 'INTERFACES_TYPE') }}"
 

--- a/ansible/projects/tasks/get_mlx_interfaces.yml
+++ b/ansible/projects/tasks/get_mlx_interfaces.yml
@@ -3,6 +3,7 @@
   set_fact:
     mlnx_interfaces: []
     mlnx_pfs: []
+    infiniband_pfs: []
     pfs: []
 
 - name: Get Mellanox interfaces
@@ -30,6 +31,41 @@
         index_var: loop_index
       when:
         - item.stat.exists
+
+- name: Get Infniband interfaces
+  when:
+    - interfaces_type == "eth" or interfaces_type == "ib"
+  block:
+    - name: Read pkeys
+      stat:
+        path: "/sys/class/net/{{ item }}/pkey"
+      loop: "{{ mlnx_pfs }}"
+      register: interfaces_pkey
+
+    - name: Get Mellanox Infiniband PFs
+      set_fact:
+        infiniband_pfs: "{{ infiniband_pfs + [ mlnx_pfs[loop_index] ] }}"
+      loop: "{{ interfaces_pkey.results }}"
+      loop_control:
+        index_var: loop_index
+      when:
+        - item.stat.exists
+
+- name: Filter out Infniband interfaces
+  when:
+    - interfaces_type == "eth"
+  block:
+    - name: Filter out Infiniband pfs
+      set_fact:
+        mlnx_pfs: "{{ mlnx_pfs | difference(infiniband_pfs) }}"
+
+- name: Filter out Ethernet Mellanox pfs
+  when:
+    - interfaces_type == "ib"
+  block:
+    - name: Filter out Ethernet pfs
+      set_fact:
+        mlnx_pfs: "{{ infiniband_pfs }}"
 
 - name: Filter Mellanox pfs
   block:

--- a/run_kind_ci.sh
+++ b/run_kind_ci.sh
@@ -11,7 +11,7 @@ export PHASES_TO_RUN=("${KIND_CI_PHASES[@]}")
 usage() {
   echo "usage: run_kind_ci.sh [[--project <name>] [--phases <phases>] [--skip-phases <phases>]"
   echo "                       [--num-workers <num>] [--kind-config <conf-fil>] [--kubeconfig <path>]"
-  echo "                       [--kind-node-image <image>] [-h]]"
+  echo "                       [--kind-node-image <image>] [--interfaces-type <interfaces-type>] [-h]]"
   echo ""
   echo "--project              Project to run CI: ${KIND_CI_PROJECTS[*]}"
   echo "                       Required field"
@@ -19,6 +19,7 @@ usage() {
   echo "--skip-phases          Comma separated phases, phases: ${KIND_CI_PHASES[*]}"
   echo "--num-workers          Number of worker nodes. DEFAULT: 2 worker"
   echo "--pf-per-worker        How many PFs to switch for each worker node"
+  echo "--interfaces-type      Specify the interfaces type to switch into the kind node. support: "eth", "ib", or "both". Default: eth"
   echo "--kind-config          Kind configuration file, if provided skip rendering related parameters"
   echo "                       if provided, ignores rendering related parameters (num-workers)"
   echo "--kubeconfig           KUBECONFIG for kind cluster"
@@ -118,6 +119,10 @@ parse_args() {
       fi
       export PF_PER_WORKER=$1
       ;;
+    --interfaces-type)
+      shift
+      export INTERFACES_TYPE="$2"
+      ;;
     --kind-config)
       shift
       kind_conf=$1
@@ -177,6 +182,7 @@ set_default_params() {
   export PF_PER_WORKER=${PF_PER_WORKER:-1}
   export KUBECONFIG=${KUBECONFIG:-$HOME/admin.conf}
   export KIND_NODE_IMAGE="${KIND_NODE_IMAGE:-''}"
+  export INTERFACES_TYPE=${INTERFACES_TYPE:-"eth"}
 }
 
 print_params() {
@@ -191,6 +197,7 @@ print_params() {
   echo "KIND_CONFIG     = ${KIND_CONFIG}"
   echo "KUBECONFIG      = ${KUBECONFIG}"
   echo "PULL_REQUEST    = ${PULL_REQUEST}"
+  echo "INTERFACES_TYPE = ${INTERFACES_TYPE}"
   echo ""
 }
 


### PR DESCRIPTION
Filter out infniband interfaces by default from the get_mlnx_interfaces
role. This is done because infiniband interfaces by default require
special procedures to become up, and by default what is needed is ethernet.
This also is done to guarantee testing ethernet by default, and only testing
infniband when required.