### PR TITLE
Add nic-operator hostdevice IB test

### DIFF
--- a/ansible/projects/nic-operator-kind/environment.sh
+++ b/ansible/projects/nic-operator-kind/environment.sh
@@ -1,0 +1,2 @@
+export INTERFACES_TYPE=${INTERFACES_TYPE:-'both'}
+

--- a/nic_operator_kind/nic_operator_kind_ci_start.sh
+++ b/nic_operator_kind/nic_operator_kind_ci_start.sh
@@ -78,6 +78,8 @@ function main {
 
     cp ./deploy/macvlan-net.yaml "$ARTIFACTS"/
 
+    sudo modprobe ib_ipoib
+
     deploy_kind_cluster "$project" "1" "2"
     if [ $? -ne 0 ]; then
         echo "Failed to deploy k8s"

--- a/nic_operator_kind/nic_operator_kind_ci_stop.sh
+++ b/nic_operator_kind/nic_operator_kind_ci_stop.sh
@@ -26,6 +26,8 @@ function main {
     stop_kind_cluster "nic-operator-kind"
 
     general_cleaning
+
+    sudo systemctl stop opensm
  
     load_core_drivers                                                                                                                                                                                                                            
     cp /tmp/kube*.log $LOGDIR

--- a/nic_operator_kind/nic_operator_kind_ci_test.sh
+++ b/nic_operator_kind/nic_operator_kind_ci_test.sh
@@ -49,6 +49,8 @@ function main {
 
     load_core_drivers
 
+    sudo systemctl stop opensm
+
     export SRIOV_INTERFACE=$(read_netdev_from_vf_switcher_confs)
 
     set_network_operator_images_variables
@@ -73,6 +75,20 @@ function main {
     let status=$status+$?
     if [[ "$status" != "0" ]]; then
         echo "Error: Test deploying OFED and host device failed!!"
+        exit_code $status
+    fi
+
+    test_host_device_ib
+    let status=$status+$?
+    if [[ "$status" != "0" ]]; then
+        echo "Error: Test deploying the infiniband host device failed!!"
+        exit_code $status
+    fi
+
+    test_ofed_and_host_device_ib
+    let status=$status+$?
+    if [[ "$status" != "0" ]]; then
+        echo "Error: Test deploying OFED and infiniband host device failed!!"
         exit_code $status
     fi
 


### PR DESCRIPTION
Added a test to test hostdevice plugin of the network operator with
infiniband interfaces. The test was added to the nic_operator_kind
project, and would test deploying two pods with infniband interfaces,
and test rping between the two pods using hostdevice plugin.