### PR TITLE
Get interface RDMA resource for ib_write_bw command

### DIFF
--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -40,6 +40,7 @@ export CNI_BIN_DIR=${CNI_BIN_DIR:-/opt/cni/bin/}
 export CNI_CONF_DIR=${CNI_CONF_DIR:-/etc/cni/net.d/}
 
 export SRIOV_INTERFACE=${SRIOV_INTERFACE:-auto_detect}
+export RDMA_RESOURCE=${RDMA_RESOURCE:-"auto_detect"}
 
 # generate random network
 N=$((1 + RANDOM % 128))
@@ -949,12 +950,13 @@ function test_gpu_write_bandwidth {
     echo "$pod_name1 has ip ${ip_1}"
 
     if ! rdma_resource=$(kubectl exec -t cuda-test-pod-1 -- ls /sys/class/net/net1/device/infiniband); then
-        rdma_resource=$(kubectl exec -t cuda-test-pod-1 -- ls /sys/class/infiniband | head -n 1 | awk '{print $1}')
+        rdma_resource=${RDMA_RESOURCE}
     fi
 
-    screen -S gpu_server -d -m bash -x -c "kubectl exec -t $pod_name1 -- ib_write_bw -d $rdma_resource -F -R -q 2 --use_cuda=0"
+
+    screen -S gpu_server -d -m bash -x -c "kubectl exec -t $pod_name1 -- ib_write_bw -d "${rdma_resource}" -F -R -q 2 --use_cuda=0"
     sleep 20
-    kubectl exec -t $pod_name1 -- ib_write_bw -d "$rdma_resource" -F -R -q 2 --use_cuda=0 "$ip_1"
+    kubectl exec -t $pod_name1 -- ib_write_bw -d "${rdma_resource}" -F -R -q 2 --use_cuda=0 "$ip_1"
     return $?
 }
 
@@ -1117,3 +1119,21 @@ function get_pf_device_id {
     fi
 }
 
+function get_interface_rdma_resource_name {
+    local interface=${1:-"$SRIOV_INTERFACE"}
+
+    if [[ -z "${interface}" ]];then
+        interface=$(get_auto_net_device)
+    fi
+
+    if [[ ! -e /sys/class/net/${interface} ]];then
+        if [[ -n "${project}" ]];then
+            sudo docker exec -t ${project}-worker ls /sys/class/net/${interface}/device/infiniband
+            return 0
+        fi
+
+        return 1
+    fi
+
+    ls /sys/class/net/${interface}/device/infiniband
+}

--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -51,6 +51,10 @@ function main {
         export SRIOV_INTERFACE=$(ls -l /sys/class/net/ | grep $(lspci |grep Mellanox | grep -Ev 'MT27500|MT27520' | head -n1 | awk '{print $1}') | awk '{print $9}')
     fi
 
+    if [[ "${RDMA_RESOURCE}" == "auto_detect" ]];then
+        export RDMA_RESOURCE=$(get_interface_rdma_resource_name)
+    fi
+
     set_network_operator_images_variables
 
     test_rdma_only


### PR DESCRIPTION
RDMA resources are being fetched for the ib_write_bw based on alphabitic
order of the RDMA devices inside the testing pod. This in normal cases,
is not an issue, but in case of mixed ethernet and infiniband setup, this
interduces an issue that the ib_write_bw may take the RDMA resource for
an infiniband interface when it is not requested or the interface is down,
because the opensm service is down.

This patch fix that by fetching the RDMA resource name of the interface
that was configured in the rdma-shared-device-plugin.