### PR TITLE
Manually set the IFS to be spaces for fetching the mlnx interfaces

### DIFF
--- a/common/clean_common.sh
+++ b/common/clean_common.sh
@@ -390,7 +390,12 @@ function delete_cnis_bins_and_confs {
 function clear_mlnx_vfs {
     local mlnx_interfaces=$(get_auto_net_device 0)
 
+    local old_IFS=$IFS
+    IFS=' '
+
     for interface in $mlnx_interfaces;do
         sudo create_vfs.sh -i "$interface" -v "0"
     done
+
+    IFS=$old_IFS
 }

--- a/common/common_functions.sh
+++ b/common/common_functions.sh
@@ -824,6 +824,9 @@ function get_auto_net_device {
 
     local index=0
 
+    local old_IFS=$IFS
+    IFS=' '
+
     for pci in $pcis;do
         interfaces+="$(ls /sys/bus/pci/devices/"0000:$pci"/net/) "
         ((index++))
@@ -831,6 +834,8 @@ function get_auto_net_device {
             break
         fi
     done
+
+    IFS=$old_IFS
 
     echo $interfaces
 }


### PR DESCRIPTION
Running the scripts in jenkins would fail to iterate through the
space separated strings. This patch fixes that by manually specifying
the internal field separator to spaces before the for loop.