### PR TITLE
Fix pending IB interfaces for host device IB test

### DIFF
--- a/common/nic_operator_test.sh
+++ b/common/nic_operator_test.sh
@@ -430,6 +430,9 @@ function test_host_device_ib {
 
     sudo modprobe ib_ipoib
 
+    # Give some time for the vf-switcher to switch the IB interface inside the kind cluster
+    sleep 4
+
     local network_file="${ARTIFACTS}/example-ib-hostdevice-network.yaml"
 
     configure_hostdevice_network_custom_resource "$resource_name" "$network_file" "$network_name"
@@ -536,6 +539,8 @@ function test_ofed_and_host_device_ib {
     local network_file="${ARTIFACTS}/example-ib-hostdevice-network.yaml"
 
     sudo modprobe ib_ipoib
+
+    sleep 4
 
     configure_hostdevice_network_custom_resource "$resource_name" "$network_file" "$network_name"
     kubectl create -f "$network_file"

--- a/nic_operator/nic_operator_ci_test.sh
+++ b/nic_operator/nic_operator_ci_test.sh
@@ -72,6 +72,13 @@ function main {
         exit_code $status
     fi
 
+    test_ofed_and_host_device_ib
+    let status=$status+$?
+    if [[ "$status" != "0" ]]; then
+        echo "Error: Test deploying OFED and infiniband host device failed!!"
+        exit_code $status
+    fi
+
     test_nv_peer_mem
     let status=status+$?
     if [ "$status" != 0 ]; then

--- a/nic_operator_kind/nic_operator_kind_ci_test.sh
+++ b/nic_operator_kind/nic_operator_kind_ci_test.sh
@@ -85,13 +85,6 @@ function main {
         exit_code $status
     fi
 
-    test_ofed_and_host_device_ib
-    let status=$status+$?
-    if [[ "$status" != "0" ]]; then
-        echo "Error: Test deploying OFED and infiniband host device failed!!"
-        exit_code $status
-    fi
-
     test_probes
     let status=status+$?
     if [ "$status" != 0 ]; then


### PR DESCRIPTION
nic-operator-kind CI have a race a condition between the vf-switcher and
the sriov-device plugin for discovering IB interfaces. Basically the sriov
device plugin would finish its work before the vf-switcher switches all IB
interfaces into the KIND container. This happens because the ipoib module
is loaded just before deploying the nic-cluster-policy.

This patch fix that by adding a delay after loading the ib_ipoib module
to give the vf-switcher service time to switch it into the kind cluster.