### PR TITLE
Override repository name in values.yaml

### DIFF
--- a/nic_operator_helm/nic_operator_helm_ci_start.sh
+++ b/nic_operator_helm/nic_operator_helm_ci_start.sh
@@ -64,6 +64,7 @@ function configure_helm_values {
     yaml_write "node-feature-discovery.worker.tolerations[0].effect" "NoSchedule" "$file_name"
 
     yaml_write "sriovNetworkOperator.enabled" "true" $file_name
+    yaml_write "operator.repository" "mellanox" $file_name
     yaml_write "operator.tag" "latest" $file_name
     yq d -i $file_name "operator.nodeSelector"
     yaml_write "deployCR" "true" $file_name


### PR DESCRIPTION
nic_operator_helm CI builds operator image and uploads it to
temporary registry. To make sure that image is pulled from
the correct registry let's override it's name in values.yaml

Signed-off-by: Ivan Kolodyazhny <ikolodiazhny@nvidia.com>